### PR TITLE
suppress React rAF warning while testing

### DIFF
--- a/test/setupApp.js
+++ b/test/setupApp.js
@@ -15,3 +15,6 @@ global.HTMLElement = global.window.HTMLElement
 if (global.chrome === undefined) {
   global.chrome = getMockChrome()
 }
+global.requestAnimationFrame = function (cb) {
+  return setTimeout(cb, 0)
+}

--- a/test/setupApp.js
+++ b/test/setupApp.js
@@ -15,6 +15,7 @@ global.HTMLElement = global.window.HTMLElement
 if (global.chrome === undefined) {
   global.chrome = getMockChrome()
 }
+// mocks rAF to suppress React warning while testing
 global.requestAnimationFrame = function (cb) {
   return setTimeout(cb, 0)
 }


### PR DESCRIPTION
Running `yarn test` outputs a warning message from React that this change suppresses:

```
Warning: React depends on requestAnimationFrame. Make sure that you load a polyfill in older browsers. http://fb.me/react-polyfills
```

