### PR TITLE
unblock components unit testing

### DIFF
--- a/app/components/braveShields/braveShieldsControls.tsx
+++ b/app/components/braveShields/braveShieldsControls.tsx
@@ -38,7 +38,7 @@ export default class BraveShieldsControls extends React.Component<Props, object>
     this.props.blockAdsTrackers(e.target.value)
   }
 
-  onChangeCookieControl () {
+  onChangeCookieControl (e: HTMLSelectElement) {
     // TODO: @cezaraugusto
   }
 
@@ -133,6 +133,7 @@ export default class BraveShieldsControls extends React.Component<Props, object>
                 {/* TODO @cezaraugusto */}
                 <SwitchButton
                   id='blockPhishingMalware'
+                  checked={false}
                   disabled={braveShields === 'block'}
                   rightText={getMessage('shieldsControlsBlockPhishingMalwareSwitch')}
                 />

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "clean": "rimraf build/ dev/ *.zip *.crx",
     "lint": "tslint --project tsconfig.json '{app, test}/**/*.{ts,tsx}'",
     "test-e2e": "cross-env NODE_ENV=test TS_NODE_TYPE_CHECK=true mocha ./test/setupApp.ts test/e2e/braveShieldsPanel.ts && mocha ./test/setupApp.ts",
-    "test-unit": "cross-env NODE_ENV=test TS_NODE_TYPE_CHECK=true mocha -r ./test/setupApp.ts test/app/**/**/**/*.ts",
+    "test-unit": "cross-env NODE_ENV=test TS_NODE_TYPE_CHECK=true mocha -r ignore-styles ./test/setupApp.ts test/app/**/**/**/*.ts",
     "test-suite": "node ./scripts/tests.js"
   },
   "repository": {
@@ -64,6 +64,7 @@
     "css-loader": "^0.28.7",
     "css-modules-require-hook": "^4.2.2",
     "extract-text-webpack-plugin": "^3.0.2",
+    "ignore-styles": "^5.0.1",
     "jsdom": "^11.4.0",
     "minimist": "^1.2.0",
     "mocha": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "clean": "rimraf build/ dev/ *.zip *.crx",
     "lint": "tslint --project tsconfig.json '{app, test}/**/*.{ts,tsx}'",
     "test-e2e": "cross-env NODE_ENV=test TS_NODE_TYPE_CHECK=true mocha ./test/setupApp.ts test/e2e/braveShieldsPanel.ts && mocha ./test/setupApp.ts",
-    "test-unit": "cross-env NODE_ENV=test TS_NODE_TYPE_CHECK=true mocha -r ignore-styles ./test/setupApp.ts test/app/**/**/**/*.ts",
+    "test-unit": "cross-env NODE_ENV=test TS_NODE_TYPE_CHECK=true mocha -r ignore-styles ./test/setupApp.ts test/app/**/**/**/*.{ts,tsx}",
     "test-suite": "node ./scripts/tests.js"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
   "dependencies": {
     "@types/selenium-webdriver": "^3.0.8",
     "bluebird": "^3.5.1",
-    "brave-ui": "0.3.0-0",
+    "brave-ui": "^0.6.0",
     "classnames": "^2.2.5",
     "deep-freeze-node": "^1.1.3",
     "react": "^16.1.1",

--- a/test/app/components/braveShields/braveShieldsControlsTest.tsx
+++ b/test/app/components/braveShields/braveShieldsControlsTest.tsx
@@ -10,7 +10,7 @@ import { renderIntoDocument } from 'react-dom/test-utils'
 import BraveShieldsControls, { Props } from '../../../../app/components/braveShields/braveShieldsControls'
 import { BlockOptions } from '../../../../app/types/other/blockTypes'
 import * as actionTypes from '../../../../app/constants/shieldsPanelTypes'
-import { Props as UIProps } from 'brave-ui'
+import { GridProps } from 'brave-ui/gridSystem'
 
 function setup () {
   const props: Props = {
@@ -51,7 +51,7 @@ function setup () {
   }
 
   const renderer = renderIntoDocument(<BraveShieldsControls {...props} />) as React.Component<BraveShieldsControls>
-  const result = renderer.render() as React.ReactElement<UIProps.Grid>
+  const result = renderer.render() as React.ReactElement<GridProps>
   return { props, result, renderer }
 }
 

--- a/test/app/components/braveShields/braveShieldsControlsTest.tsx
+++ b/test/app/components/braveShields/braveShieldsControlsTest.tsx
@@ -46,6 +46,8 @@ function setup () {
     fingerprintingToggled: () => {
       return {
         type: actionTypes.FINGERPRINTING_TOGGLED
+      }
+    }
   }
 
   const renderer = renderIntoDocument(<BraveShieldsControls {...props} />) as React.Component<BraveShieldsControls>

--- a/test/app/components/braveShields/braveShieldsFooterTest.tsx
+++ b/test/app/components/braveShields/braveShieldsFooterTest.tsx
@@ -8,12 +8,12 @@ import * as React from 'react'
 import * as assert from 'assert'
 import { renderIntoDocument } from 'react-dom/test-utils'
 import BraveShieldsFooter from '../../../../app/components/braveShields/braveShieldsFooter'
-import { Props as UIProps } from 'brave-ui'
+import { GridProps } from 'brave-ui/gridSystem'
 
 function setup () {
   const props = {}
   const renderer = renderIntoDocument(<BraveShieldsFooter {...props} />) as React.Component<BraveShieldsFooter>
-  const result = renderer.render() as React.ReactElement<UIProps.Grid>
+  const result = renderer.render() as React.ReactElement<GridProps>
   return { props, result, renderer }
 }
 

--- a/test/app/components/braveShields/braveShieldsHeaderTest.tsx
+++ b/test/app/components/braveShields/braveShieldsHeaderTest.tsx
@@ -8,7 +8,7 @@ import * as React from 'react'
 import * as assert from 'assert'
 import { renderIntoDocument } from 'react-dom/test-utils'
 import BraveShieldsHeader, { Props } from '../../../../app/components/braveShields/braveShieldsHeader'
-import { Props as UIProps } from 'brave-ui'
+import { GridProps } from 'brave-ui/gridSystem'
 import { BlockOptions } from '../../../../app/types/other/blockTypes';
 import * as actionTypes from '../../../../app/constants/shieldsPanelTypes'
 
@@ -24,7 +24,7 @@ function setup () {
     braveShields: 'allow'
   }
   const renderer = renderIntoDocument(<BraveShieldsHeader {...props} />) as React.Component<BraveShieldsHeader>
-  const result= renderer.render() as React.ReactElement<UIProps.Grid>
+  const result= renderer.render() as React.ReactElement<GridProps>
   return { props, result, renderer }
 }
 

--- a/test/app/components/braveShields/braveShieldsStatsTest.tsx
+++ b/test/app/components/braveShields/braveShieldsStatsTest.tsx
@@ -8,7 +8,7 @@ import * as React from 'react'
 import * as assert from 'assert'
 import { renderIntoDocument } from 'react-dom/test-utils'
 import BraveShieldsStats from '../../../../app/components/braveShields/braveShieldsStats'
-import { Props as UIProps } from 'brave-ui'
+import { GridProps } from 'brave-ui/gridSystem'
 import { Props } from '../../../../app/components/braveShields/braveShieldsStats';
 
 function setup () {
@@ -21,7 +21,7 @@ function setup () {
     fingerprintingBlocked: 5
   }
   const renderer = renderIntoDocument(<BraveShieldsStats {...props} />) as React.Component<BraveShieldsStats>
-  const result = renderer.render() as React.ReactElement<UIProps.Grid>
+  const result = renderer.render() as React.ReactElement<GridProps>
   return { props, result, renderer }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -235,14 +235,6 @@ anymatch@^1.3.0:
     arrify "^1.0.0"
     micromatch "^2.1.5"
 
-aphrodite@^1.2.5:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/aphrodite/-/aphrodite-1.2.5.tgz#8358c36c80bb03aee9b97165aaa70186225b4983"
-  dependencies:
-    asap "^2.0.3"
-    inline-style-prefixer "^3.0.1"
-    string-hash "^1.1.3"
-
 aproba@^1.0.3:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.1.1.tgz#95d3600f07710aa0e9298c726ad5ecf2eacbabab"
@@ -337,7 +329,7 @@ arrify@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
 
-asap@^2.0.3, asap@~2.0.3:
+asap@~2.0.3:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
 
@@ -1226,10 +1218,6 @@ boom@5.x.x:
   dependencies:
     hoek "4.x.x"
 
-bowser@^1.7.3:
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/bowser/-/bowser-1.8.1.tgz#49785777e7302febadb1a5b71d9a646520ed310d"
-
 brace-expansion@^1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.7.tgz#3effc3c50e000531fb720eaff80f0ae8ef23cf59"
@@ -1261,13 +1249,9 @@ braces@^2.3.0:
     split-string "^3.0.2"
     to-regex "^3.0.1"
 
-brave-ui@0.3.0-0:
-  version "0.3.0-0"
-  resolved "https://registry.yarnpkg.com/brave-ui/-/brave-ui-0.3.0-0.tgz#e8ac56064bdaa02d474d0ee1446067bb445edc56"
-  dependencies:
-    "@types/react" "^16.0.26"
-    aphrodite "^1.2.5"
-    react "^16.0.0"
+brave-ui@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/brave-ui/-/brave-ui-0.6.0.tgz#766ff4d4e066dad0d13dd2cd0a19cc364b5f5f99"
 
 brorand@^1.0.1:
   version "1.1.0"
@@ -1791,12 +1775,6 @@ crypto-browserify@^3.11.0:
 css-color-names@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/css-color-names/-/css-color-names-0.0.4.tgz#808adc2e79cf84738069b646cb20ec27beb629e0"
-
-css-in-js-utils@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/css-in-js-utils/-/css-in-js-utils-2.0.0.tgz#5af1dd70f4b06b331f48d22a3d86e0786c0b9435"
-  dependencies:
-    hyphenate-style-name "^1.0.2"
 
 css-loader@^0.28.7:
   version "0.28.7"
@@ -2838,10 +2816,6 @@ https-browserify@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-0.0.1.tgz#3f91365cabe60b77ed0ebba24b454e3e09d95a82"
 
-hyphenate-style-name@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.2.tgz#31160a36930adaf1fc04c6074f7eb41465d4ec4b"
-
 iconv-lite@0.4.13:
   version "0.4.13"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.13.tgz#1f88aba4ab0b1508e8312acc39345f36e992e2f2"
@@ -2900,13 +2874,6 @@ inherits@2.0.1:
 ini@~1.3.0:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.4.tgz#0537cb79daf59b59a1a517dff706c86ec039162e"
-
-inline-style-prefixer@^3.0.1:
-  version "3.0.8"
-  resolved "https://registry.yarnpkg.com/inline-style-prefixer/-/inline-style-prefixer-3.0.8.tgz#8551b8e5b4d573244e66a34b04f7d32076a2b534"
-  dependencies:
-    bowser "^1.7.3"
-    css-in-js-utils "^2.0.0"
 
 interpret@^1.0.0:
   version "1.0.3"
@@ -4639,15 +4606,6 @@ react-transform-hmr@^1.0.3:
     global "^4.3.0"
     react-proxy "^1.1.7"
 
-react@^16.0.0:
-  version "16.2.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.2.0.tgz#a31bd2dab89bff65d42134fa187f24d054c273ba"
-  dependencies:
-    fbjs "^0.8.16"
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.0"
-
 react@^16.1.1:
   version "16.1.1"
   resolved "https://registry.yarnpkg.com/react/-/react-16.1.1.tgz#d5c4ef795507e3012282dd51261ff9c0e824fe1f"
@@ -5224,10 +5182,6 @@ stream-http@^2.3.1:
 strict-uri-encode@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
-
-string-hash@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/string-hash/-/string-hash-1.1.3.tgz#e8aafc0ac1855b4666929ed7dd1275df5d6c811b"
 
 string-width@^1.0.1:
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2844,6 +2844,10 @@ ieee754@^1.1.4:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.8.tgz#be33d40ac10ef1926701f6f08a2d86fbfd1ad3e4"
 
+ignore-styles@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/ignore-styles/-/ignore-styles-5.0.1.tgz#b49ef2274bdafcd8a4880a966bfe38d1a0bf4671"
+
 immediate@~3.0.5:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.0.6.tgz#9db1dbd0faf8de6fbe0f5dd5e56bb606280de69b"


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/147

Covered:

* Update brave-ui to v0.6.0 (latest)
* Update type definitions in components testing
* Mocks CSS imports in all unit tests (needs security audit)
* Fix missing bracket in `braveShieldsControlsTest.tsx`

Test Plan:

* `yarn test-unit` should pass, including `tsx` files testing