### PR TITLE
Update @types/react-redux to fix TS2344 error during build

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@types/node": "^8.0.54",
     "@types/react": "^16.0.26",
     "@types/react-dom": "^16.0.3",
-    "@types/react-redux": "^5.0.14",
+    "@types/react-redux": "^5.0.20",
     "@types/redux-logger": "^3.0.5",
     "@types/sinon": "^4.1.0",
     "awesome-typescript-loader": "^5.0.0-1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -84,9 +84,9 @@
     "@types/node" "*"
     "@types/react" "*"
 
-"@types/react-redux@^5.0.14":
-  version "5.0.19"
-  resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-5.0.19.tgz#d9e9af54c619b7495fffcfa23a0b8922d68316c4"
+"@types/react-redux@^5.0.20":
+  version "5.0.20"
+  resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-5.0.20.tgz#a332f2a97043d6127159956a4639a9fb5dc1f5dc"
   dependencies:
     "@types/react" "*"
     redux "^3.6.0"
@@ -412,7 +412,7 @@ autoprefixer@^6.3.1:
     postcss "^5.2.16"
     postcss-value-parser "^3.2.3"
 
-awesome-typescript-loader@^5.0.0:
+awesome-typescript-loader@^5.0.0-1:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/awesome-typescript-loader/-/awesome-typescript-loader-5.0.0.tgz#130c304ae52a60933f15d93f7629003b483fa8b1"
   dependencies:
@@ -5765,7 +5765,7 @@ redux-logger@^3.0.6:
   dependencies:
     deep-diff "^0.3.5"
 
-redux-thunk@^2.2.0:
+redux-thunk@2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.2.0.tgz#e615a16e16b47a19a515766133d1e3e99b7852e5"
 
@@ -6794,9 +6794,9 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript@^2.6.2:
-  version "2.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.8.3.tgz#5d817f9b6f31bb871835f4edf0089f21abe6c170"
+typescript@^2.8.1:
+  version "2.9.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.1.tgz#fdb19d2c67a15d11995fd15640e373e09ab09961"
 
 ua-parser-js@^0.7.9:
   version "0.7.17"


### PR DESCRIPTION
brave-extension's package.json requires `typescript@^2.8.1`, which now resolves to `2.9.1` as of the recent [release](https://www.npmjs.com/package/typescript) of Typescript 2.9 (4 days ago). This in turn requires us to upgrade `@types/react-redux` to 5.0.20, since that version includes a compatibility [fix](https://github.com/DefinitelyTyped/DefinitelyTyped/commit/b73b4426dd1cd78b7ddf4f4d1cc5b6316fd6956f#diff-e17ae37682234ef10ed127a622634fcb) for Typescript 2.9.

Note that the changes to `yarn.lock` also include updated package versions required by the changes to brave-extensions's package.json in #26. It's my understanding that it's best practice to keep NPM/yarn lockfiles in version control, so these changes should have been included as part of #26; I asked https://github.com/brave/brave-extension/pull/26#issuecomment-394517438 to clarify best practice going forward.

Fixes brave/brave-browser#269.