### PR TITLE
Change node builder from npm to yarn

### DIFF
--- a/py-scripts/build-brave-extension.py
+++ b/py-scripts/build-brave-extension.py
@@ -4,7 +4,7 @@ import sys
 import shutil
 from lib.util import execute_stdout, scoped_cwd
 
-NPM = 'npm'
+NPM = 'yarn'
 if sys.platform in ['win32', 'cygwin']:
   NPM += '.cmd'
 


### PR DESCRIPTION
Currently the extension is failing to build due to the following error logs. These are alleviated by using yarn instead of npm. This is likely due to different behavior resolving dependencies. After chasing the exports through `https://github.com/jsdom/jsdom/pull/2242` it seems the simplest solution is to use yarn to build.

08:30:28 ERROR in [at-loader] ./node_modules/@types/jsdom/index.d.ts:10:10 
08:30:28     TS2305: Module '"/var/lib/jenkins/workspace/brave-browser-build-linux/src/brave/vendor/brave-extension/node_modules/parse5/lib/index"' has no exported member 'ElementLocation'.
...
08:30:28 npm ERR! code ELIFECYCLE
08:30:28 npm ERR! errno 1
08:30:28 npm ERR! brave-extension@1.0.0 build: `node scripts/build`
08:30:28 npm ERR! Exit status 1
08:30:28 npm ERR! 
08:30:28 npm ERR! Failed at the brave-extension@1.0.0 build script.
08:30:28 npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
08:30:28 
08:30:28 npm ERR! A complete log of this run can be found in:
08:30:28 npm ERR!     /home/ubuntu/.npm/_logs/2018-06-06T15_30_31_103Z-debug.log
08:30:28 
08:30:28 Traceback (most recent call last):
08:30:28   File "../../brave/vendor/brave-extension/py-scripts/build-brave-extension.py", line 47, in <module>
08:30:28     sys.exit(main())
08:30:28   File "../../brave/vendor/brave-extension/py-scripts/build-brave-extension.py", line 20, in main
08:30:28     build_extension('.')
08:30:28   File "../../brave/vendor/brave-extension/py-scripts/build-brave-extension.py", line 30, in build_extension
08:30:28     execute_stdout(args, env)
08:30:28   File "/var/lib/jenkins/workspace/brave-browser-build-linux/src/brave/vendor/brave-extension/py-scripts/lib/util.py", line 165, in execute_stdout
08:30:28     execute(argv, env)
08:30:28   File "/var/lib/jenkins/workspace/brave-browser-build-linux/src/brave/vendor/brave-extension/py-scripts/lib/util.py", line 161, in execute
08:30:28     raise e
08:30:28 subprocess.CalledProcessError: Command '['npm', 'run', 'build']' returned non-zero exit status 1
08:30:28 [2304/31709] ACTION //content/public/common:resource_type_bindings__generate_message_ids(//build/toolchain/linux:clang_x64)