### PR TITLE
Hardcode jsdom 11.0.4 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@types/bluebird": "^3.5.18",
     "@types/chai": "^4.0.8",
     "@types/chrome": "^0.0.64",
-    "@types/jsdom": "^11.0.4",
+    "@types/jsdom": "11.0.4",
     "@types/mocha": "^5.2.0",
     "@types/node": "^8.0.54",
     "@types/react": "^16.0.26",


### PR DESCRIPTION
This commit hardcodes jsdom version 11.0.4 in package.json since this is the latest version that works for us. 11.0.5 breaks. See previous commit for error log.