### PR TITLE
supress webpack warning regarding dev mode

### DIFF
--- a/webpack/dev.config.js
+++ b/webpack/dev.config.js
@@ -8,6 +8,7 @@ const customPath = path.join(__dirname, './customPublicPath')
 const hotScript = 'webpack-hot-middleware/client?path=__webpack_hmr&dynamicPublicPath=true'
 
 const baseDevConfig = () => ({
+  mode: 'development',
   devtool: 'eval-cheap-module-source-map',
   entry: {
     braveShieldsPanel: [customPath, hotScript, path.join(__dirname, '../app/braveShieldsPanel')],


### PR DESCRIPTION
<img width="951" alt="screen shot 2018-06-08 at 2 28 45 pm" src="https://user-images.githubusercontent.com/4672033/41171921-82cf24fc-6b28-11e8-90f5-bd173f5edb1c.png">

This matches production config https://github.com/brave/brave-extension/blob/master/webpack/prod.config.js#L13

test plan:

* no terminal warnings regarding dev mode should be shown