### PR TITLE
add support to show blocked resources by clicking on stats

### DIFF
--- a/app/components/braveShields/braveShields.tsx
+++ b/app/components/braveShields/braveShields.tsx
@@ -47,6 +47,11 @@ export default class BraveShields extends React.Component<BraveShieldsProps, {}>
           httpsRedirected={shieldsPanelTabData.httpsRedirected}
           javascriptBlocked={shieldsPanelTabData.javascriptBlocked}
           fingerprintingBlocked={shieldsPanelTabData.fingerprintingBlocked}
+          adsBlockedResources={shieldsPanelTabData.adsBlockedResources}
+          trackersBlockedResources={shieldsPanelTabData.trackersBlockedResources}
+          httpsRedirectedResources={shieldsPanelTabData.httpsRedirectedResources}
+          javascriptBlockedResources={shieldsPanelTabData.javascriptBlockedResources}
+          fingerprintingBlockedResources={shieldsPanelTabData.fingerprintingBlockedResources}
         />
         <BraveShieldsControls
           braveShields={shieldsPanelTabData.braveShields}

--- a/app/components/braveShields/braveShieldsStats.tsx
+++ b/app/components/braveShields/braveShieldsStats.tsx
@@ -5,6 +5,7 @@
 import * as React from 'react'
 import { Grid, Column } from 'brave-ui/gridSystem'
 import TextLabel from 'brave-ui/textLabel'
+import Paragraph from 'brave-ui/paragraph'
 
 import { BlockOptions } from '../../types/other/blockTypes'
 import { getMessage } from '../../background/api/localeAPI'
@@ -17,15 +18,32 @@ export interface BraveShieldsStatsProps {
   httpsRedirected: number
   javascriptBlocked: number
   fingerprintingBlocked: number
+  adsBlockedResources: Array<string>
+  trackersBlockedResources: Array<string>
+  httpsRedirectedResources: Array<string>
+  javascriptBlockedResources: Array<string>
+  fingerprintingBlockedResources: Array<string>
 }
 
-export default class BraveShieldsStats extends React.Component<BraveShieldsStatsProps, {}> {
+export interface BraveShieldsStatsState {
+  adsTrackersBlockedDetailsOpen: boolean,
+  httpsRedirectedDetailsOpen: boolean,
+  javascriptBlockedDetailsOpen: boolean,
+  fingerprintingBlockedDetailsOpen: boolean
+}
+
+export default class BraveShieldsStats extends React.Component<BraveShieldsStatsProps, BraveShieldsStatsState> {
   constructor (props: BraveShieldsStatsProps) {
     super(props)
-    this.onClickadsTrackersBlockedStats = this.onClickadsTrackersBlockedStats.bind(this)
-    this.onClickHttpsUpgradesStats = this.onClickHttpsUpgradesStats.bind(this)
-    this.onClickScriptsBlockedStats = this.onClickScriptsBlockedStats.bind(this)
-    this.onClickFingerPrintingProtectionStats = this.onClickScriptsBlockedStats.bind(this)
+    this.onToggleBlockedResourcesDetails = this.onToggleBlockedResourcesDetails.bind(this)
+
+    // creates a temporary state to switch the toggle of blocked resources details
+    this.state = {
+      adsTrackersBlockedDetailsOpen: false,
+      httpsRedirectedDetailsOpen: false,
+      javascriptBlockedDetailsOpen: false,
+      fingerprintingBlockedDetailsOpen: false
+    }
   }
 
   get totalAdsTrackersBlocked (): number {
@@ -45,24 +63,56 @@ export default class BraveShieldsStats extends React.Component<BraveShieldsStats
     return this.props.fingerprintingBlocked
   }
 
-  onClickadsTrackersBlockedStats () {
-    // TODO #202
-    console.log('fired adsTrackersBlockedStats')
+  get totalAdsTrackersBlockedResources (): Array<string> {
+    const { adsBlockedResources, trackersBlockedResources } = this.props
+    return [ ...adsBlockedResources, ...trackersBlockedResources ]
   }
 
-  onClickHttpsUpgradesStats () {
-    // TODO #202
-    console.log('fired httpsUpgradesStats')
+  get httpsRedirectedResources (): Array<string> {
+    return this.props.httpsRedirectedResources
   }
 
-  onClickScriptsBlockedStats () {
-    // TODO #202
-    console.log('fired scriptsBlockedStats')
+  get javascriptBlockedResources (): Array<string> {
+    return this.props.javascriptBlockedResources
   }
 
-  onClickFingerPrintingProtectionStats () {
-    // TODO #202
-    console.log('fired fingerPrintingProtectionStats')
+  get fingerprintingBlockedResources (): Array<string> {
+    return this.props.fingerprintingBlockedResources
+  }
+
+  get blockedResourcesDetailsList () {
+    const {
+      adsTrackersBlockedDetailsOpen,
+      httpsRedirectedDetailsOpen,
+      javascriptBlockedDetailsOpen,
+      fingerprintingBlockedDetailsOpen
+    } = this.state
+
+    if (adsTrackersBlockedDetailsOpen) {
+      return this.setResourceBlockedItemView(this.totalAdsTrackersBlockedResources)
+    } else if (httpsRedirectedDetailsOpen) {
+      return this.setResourceBlockedItemView(this.httpsRedirectedResources)
+    } else if (javascriptBlockedDetailsOpen) {
+      return this.setResourceBlockedItemView(this.javascriptBlockedResources)
+    } else if (fingerprintingBlockedDetailsOpen) {
+      return this.setResourceBlockedItemView(this.fingerprintingBlockedResources)
+    } else {
+      return null
+    }
+  }
+
+  setResourceBlockedItemView (resource: Array<string>) {
+    return resource.map((src: string, key: number) =>
+      <Paragraph theme={theme.blockedResourcesStatsText} key={key} text={src} />)
+  }
+
+  onToggleBlockedResourcesDetails (e: any) {
+    this.setState({
+      adsTrackersBlockedDetailsOpen: e.target.id.startsWith('totalAdsTrackersBlocked'),
+      httpsRedirectedDetailsOpen: e.target.id.startsWith('httpsRedirected'),
+      javascriptBlockedDetailsOpen: e.target.id.startsWith('javascriptBlocked'),
+      fingerprintingBlockedDetailsOpen: e.target.id.startsWith('fingerprintingBlocked')
+    })
   }
 
   render () {
@@ -75,47 +125,58 @@ export default class BraveShieldsStats extends React.Component<BraveShieldsStats
       >
         <Column theme={theme.statsNumbers} size={1}>
           <TextLabel
+            id='totalAdsTrackersBlockedStat'
             theme={theme.totalAdsTrackersBlockedStat}
             text={this.totalAdsTrackersBlocked}
-            onClick={this.onClickadsTrackersBlockedStats}
+            onClick={this.onToggleBlockedResourcesDetails}
           />
           <TextLabel
+            id='httpsRedirectedStat'
             theme={theme.httpsRedirectedStat}
             text={this.httpsRedirected}
-            onClick={this.onClickHttpsUpgradesStats}
+            onClick={this.onToggleBlockedResourcesDetails}
           />
           <TextLabel
+            id='javascriptBlockedStat'
             theme={theme.javascriptBlockedStat}
             text={this.javascriptBlocked}
-            onClick={this.onClickScriptsBlockedStats}
+            onClick={this.onToggleBlockedResourcesDetails}
           />
           <TextLabel
+            id='fingerprintingBlockedStat'
             theme={theme.fingerprintingBlockedStat}
             text={this.fingerprintingBlocked}
-            onClick={this.onClickFingerPrintingProtectionStats}
+            onClick={this.onToggleBlockedResourcesDetails}
           />
         </Column>
         <Column theme={theme.statsNames} size={11}>
           <TextLabel
+            id='totalAdsTrackersBlockedText'
             theme={theme.totalAdsTrackersBlockedText}
             text={getMessage('shieldsStatsAdsTrackersBlocked')}
-            onClick={this.onClickadsTrackersBlockedStats}
+            onClick={this.onToggleBlockedResourcesDetails}
           />
           <TextLabel
+            id='httpsRedirectedText'
             theme={theme.httpsRedirectedText}
             text={getMessage('shieldsStatsHttpsUpgrades')}
-            onClick={this.onClickHttpsUpgradesStats}
+            onClick={this.onToggleBlockedResourcesDetails}
           />
           <TextLabel
+            id='javascriptBlockedText'
             theme={theme.javascriptBlockedText}
             text={getMessage('shieldsStatsScriptsBlocked')}
-            onClick={this.onClickScriptsBlockedStats}
+            onClick={this.onToggleBlockedResourcesDetails}
           />
           <TextLabel
+            id='fingerprintingBlockedText'
             theme={theme.fingerprintingBlockedText}
             text={getMessage('shieldsFingerPrintingBlocked')}
-            onClick={this.onClickFingerPrintingProtectionStats}
+            onClick={this.onToggleBlockedResourcesDetails}
           />
+        </Column>
+        <Column id='blockedResourcesStats' theme={theme.blockedResourcesStats} size={12}>
+          {this.blockedResourcesDetailsList}
         </Column>
       </Grid>
     )

--- a/app/state/shieldsPanelState.ts
+++ b/app/state/shieldsPanelState.ts
@@ -39,7 +39,12 @@ export const updateTabShieldsData: shieldState.UpdateTabShieldsData = (state, ta
     javascript: 'allow',
     fingerprinting: 'allow',
     controlsOpen: true,
-    noScriptInfo: {}
+    noScriptInfo: {},
+    adsBlockedResources: [],
+    trackersBlockedResources: [],
+    httpsRedirectedResources: [],
+    javascriptBlockedResources: [],
+    fingerprintingBlockedResources: []
   },
     ...tabs[tabId],
     ...details
@@ -50,21 +55,43 @@ export const updateTabShieldsData: shieldState.UpdateTabShieldsData = (state, ta
 
 export const updateResourceBlocked: shieldState.UpdateResourceBlocked = (state, tabId, blockType, subresource) => {
   const tabs: shieldState.Tabs = { ...state.tabs }
-  tabs[tabId] = { ...{ adsBlocked: 0, trackersBlocked: 0, httpsRedirected: 0, javascriptBlocked: 0, fingerprintingBlocked: 0, noScriptInfo: {} }, ...tabs[tabId] }
+  tabs[tabId] = {
+    ...{
+      adsBlocked: 0,
+      trackersBlocked: 0,
+      httpsRedirected: 0,
+      javascriptBlocked: 0,
+      fingerprintingBlocked: 0,
+      noScriptInfo: {},
+      adsBlockedResources: [],
+      trackersBlockedResources: [],
+      httpsRedirectedResources: [],
+      javascriptBlockedResources: [],
+      fingerprintingBlockedResources: []
+    },
+    ...tabs[tabId]
+  }
+
   if (blockType === 'ads') {
     tabs[tabId].adsBlocked++
+    tabs[tabId].adsBlockedResources = [ ...tabs[tabId].adsBlockedResources, subresource ]
   } else if (blockType === 'trackers') {
     tabs[tabId].trackersBlocked++
+    tabs[tabId].trackersBlockedResources = [ ...tabs[tabId].trackersBlockedResources, subresource ]
   } else if (blockType === 'httpUpgradableResources') {
     tabs[tabId].httpsRedirected++
+    tabs[tabId].httpsRedirectedResources = [ ...tabs[tabId].httpsRedirectedResources, subresource ]
   } else if (blockType === 'javascript') {
     const origin = new window.URL(subresource).origin + '/'
     tabs[tabId].javascriptBlocked++
     tabs[tabId].noScriptInfo = { ...tabs[tabId].noScriptInfo }
     tabs[tabId].noScriptInfo[origin] = { ...{ actuallyBlocked: true, willBlock: true } }
+    tabs[tabId].javascriptBlockedResources = [ ...tabs[tabId].javascriptBlockedResources, subresource ]
   } else if (blockType === 'fingerprinting') {
     tabs[tabId].fingerprintingBlocked++
+    tabs[tabId].fingerprintingBlockedResources = [ ...tabs[tabId].fingerprintingBlockedResources, subresource ]
   }
+
   return { ...state, tabs }
 }
 

--- a/app/theme.ts
+++ b/app/theme.ts
@@ -101,6 +101,14 @@ const theme = {
   noScript: {
     padding: '10px 0',
     gridGap: '10px 5px'
+  },
+  blockedResourcesStats: {
+    flexDirection: 'column',
+    overflow: 'hidden'
+  },
+  blockedResourcesStatsText: {
+    fontSize: '10px',
+    margin: '0 0 3px'
   }
 }
 

--- a/app/types/state/shieldsPannelState.ts
+++ b/app/types/state/shieldsPannelState.ts
@@ -24,6 +24,11 @@ export interface Tab {
   fingerprintingBlocked: number
   cookies: BlockCookiesOptions
   noScriptInfo: NoScriptInfo
+  adsBlockedResources: Array<string>
+  trackersBlockedResources: Array<string>
+  httpsRedirectedResources: Array<string>
+  javascriptBlockedResources: Array<string>
+  fingerprintingBlockedResources: Array<string>
 }
 
 export interface Tabs {

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
   "dependencies": {
     "@types/selenium-webdriver": "^3.0.8",
     "bluebird": "^3.5.1",
-    "brave-ui": "^0.10.6",
+    "brave-ui": "^0.10.11",
     "classnames": "^2.2.5",
     "deep-freeze-node": "^1.1.3",
     "enzyme": "^3.3.0",

--- a/test/app/actions/shieldsPanelActionsTest.ts
+++ b/test/app/actions/shieldsPanelActionsTest.ts
@@ -7,8 +7,8 @@ import 'mocha'
 import * as assert from 'assert'
 import * as types from '../../../app/constants/shieldsPanelTypes'
 import * as actions from '../../../app/actions/shieldsPanelActions'
-import { ShieldDetails, BlockDetails } from '../../../app/types/actions/shieldsPanelActions';
-import { BlockOptions, BlockFPOptions, BlockCookiesOptions } from '../../../app/types/other/blockTypes';
+import { ShieldDetails, BlockDetails } from '../../../app/types/actions/shieldsPanelActions'
+import { BlockOptions, BlockFPOptions, BlockCookiesOptions } from '../../../app/types/other/blockTypes'
 
 describe('shieldsPanelActions', () => {
   it('shieldsPanelDataUpdated', () => {

--- a/test/app/background/reducers/shieldsPanelReducerTest.ts
+++ b/test/app/background/reducers/shieldsPanelReducerTest.ts
@@ -17,9 +17,9 @@ import * as badgeAPI from '../../../../app/background/api/badgeAPI'
 import * as shieldsPanelState from '../../../../app/state/shieldsPanelState'
 import { initialState } from '../../../testData'
 import * as deepFreeze from 'deep-freeze-node'
-import { ShieldDetails } from '../../../../app/types/actions/shieldsPanelActions';
+import { ShieldDetails } from '../../../../app/types/actions/shieldsPanelActions'
 import * as actions from '../../../../app/actions/shieldsPanelActions'
-import { State } from '../../../../app/types/state/shieldsPannelState';
+import { State } from '../../../../app/types/state/shieldsPannelState'
 
 describe('braveShieldsPanelReducer', () => {
   it('should handle initial state', () => {
@@ -260,7 +260,12 @@ describe('braveShieldsPanelReducer', () => {
         ads: 'block',
         fingerprinting: 'block',
         cookies: 'block',
-        noScriptInfo: {}
+        noScriptInfo: {},
+        adsBlockedResources: [],
+        fingerprintingBlockedResources: [],
+        httpsRedirectedResources: [],
+        javascriptBlockedResources: [],
+        trackersBlockedResources: []
       }
     },
     windows: {
@@ -306,7 +311,12 @@ describe('braveShieldsPanelReducer', () => {
               cookies: 'block',
               controlsOpen: true,
               braveShields: 'allow',
-              noScriptInfo: {}
+              noScriptInfo: {},
+              adsBlockedResources: [],
+              fingerprintingBlockedResources: [],
+              httpsRedirectedResources: [],
+              javascriptBlockedResources: [],
+              trackersBlockedResources: []
             }
           },
           windows: {}
@@ -435,7 +445,12 @@ describe('braveShieldsPanelReducer', () => {
             ads: 'block',
             fingerprinting: 'block',
             cookies: 'block',
-            noScriptInfo: {}
+            noScriptInfo: {},
+            adsBlockedResources: [],
+            fingerprintingBlockedResources: [],
+            httpsRedirectedResources: [],
+            javascriptBlockedResources: [],
+            trackersBlockedResources: []
           }
         },
         windows: {
@@ -463,6 +478,7 @@ describe('braveShieldsPanelReducer', () => {
           subresource: 'https://test.brave.com/index.js'
         }
       })
+
       assert.deepEqual(nextState, {
         currentWindowId: 1,
         tabs: {
@@ -485,7 +501,12 @@ describe('braveShieldsPanelReducer', () => {
             cookies: 'block',
             noScriptInfo: {
               'https://test.brave.com/': { actuallyBlocked: true, willBlock: true }
-            }
+            },
+            trackersBlockedResources: [],
+            adsBlockedResources: [],
+            fingerprintingBlockedResources: [],
+            httpsRedirectedResources: [],
+            javascriptBlockedResources: [ 'https://test.brave.com/index.js' ]
           }
         },
         windows: {
@@ -525,7 +546,12 @@ describe('braveShieldsPanelReducer', () => {
             cookies: 'block',
             noScriptInfo: {
               'https://a.com/': { actuallyBlocked: true, willBlock: true }
-            }
+            },
+            trackersBlockedResources: [],
+            adsBlockedResources: [],
+            fingerprintingBlockedResources: [],
+            httpsRedirectedResources: [],
+            javascriptBlockedResources: [ 'https://a.com/index.js' ]
           }
         },
         windows: {
@@ -564,7 +590,15 @@ describe('braveShieldsPanelReducer', () => {
             noScriptInfo: {
               'https://a.com/': { actuallyBlocked: true, willBlock: true },
               'https://b.com/': { actuallyBlocked: true, willBlock: true }
-            }
+            },
+            trackersBlockedResources: [],
+            adsBlockedResources: [],
+            fingerprintingBlockedResources: [],
+            httpsRedirectedResources: [],
+            javascriptBlockedResources: [
+              'https://a.com/index.js',
+              'https://b.com/index.js'
+            ]
           }
         },
         windows: {
@@ -603,7 +637,16 @@ describe('braveShieldsPanelReducer', () => {
             noScriptInfo: {
               'https://a.com/': { actuallyBlocked: true, willBlock: true },
               'https://b.com/': { actuallyBlocked: true, willBlock: true }
-            }
+            },
+            trackersBlockedResources: [],
+            adsBlockedResources: [],
+            fingerprintingBlockedResources: [],
+            httpsRedirectedResources: [],
+            javascriptBlockedResources: [
+              'https://a.com/index.js',
+              'https://b.com/index.js',
+              'https://a.com/index.js'
+            ]
           }
         },
         windows: {
@@ -641,7 +684,12 @@ describe('braveShieldsPanelReducer', () => {
             ads: 'block',
             fingerprinting: 'block',
             cookies: 'block',
-            noScriptInfo: {}
+            noScriptInfo: {},
+            trackersBlockedResources: [],
+            adsBlockedResources: [],
+            fingerprintingBlockedResources: [ 'https://test.brave.com' ],
+            httpsRedirectedResources: [],
+            javascriptBlockedResources: []
           }
         },
         windows: {
@@ -679,7 +727,12 @@ describe('braveShieldsPanelReducer', () => {
             ads: 'block',
             fingerprinting: 'block',
             cookies: 'block',
-            noScriptInfo: {}
+            noScriptInfo: {},
+            trackersBlockedResources: [],
+            adsBlockedResources: [ 'https://test.brave.com' ],
+            fingerprintingBlockedResources: [],
+            httpsRedirectedResources: [],
+            javascriptBlockedResources: []
           }
         },
         windows: {
@@ -715,7 +768,15 @@ describe('braveShieldsPanelReducer', () => {
             ads: 'block',
             fingerprinting: 'block',
             cookies: 'block',
-            noScriptInfo: {}
+            noScriptInfo: {},
+            trackersBlockedResources: [],
+            adsBlockedResources: [
+              'https://test.brave.com',
+              'https://test.brave.com'
+            ],
+            fingerprintingBlockedResources: [],
+            httpsRedirectedResources: [],
+            javascriptBlockedResources: []
           }
         },
         windows: {
@@ -752,7 +813,14 @@ describe('braveShieldsPanelReducer', () => {
             ads: 'block',
             fingerprinting: 'block',
             cookies: 'block',
-            noScriptInfo: {}
+            noScriptInfo: {},
+            trackersBlockedResources: [],
+            adsBlockedResources: [
+              'https://test.brave.com'
+            ],
+            fingerprintingBlockedResources: [],
+            httpsRedirectedResources: [],
+            javascriptBlockedResources: []
           }
         },
         windows: {
@@ -789,7 +857,12 @@ describe('braveShieldsPanelReducer', () => {
             ads: 'block',
             fingerprinting: 'block',
             cookies: 'block',
-            noScriptInfo: {}
+            noScriptInfo: {},
+            trackersBlockedResources: [],
+            adsBlockedResources: [ 'https://test.brave.com' ],
+            fingerprintingBlockedResources: [],
+            httpsRedirectedResources: [],
+            javascriptBlockedResources: []
           },
           3: {
             adsBlocked: 1,
@@ -797,11 +870,16 @@ describe('braveShieldsPanelReducer', () => {
             httpsRedirected: 0,
             javascriptBlocked: 0,
             fingerprintingBlocked: 0,
-            noScriptInfo: {}
+            noScriptInfo: {},
+            trackersBlockedResources: [],
+            adsBlockedResources: [ 'https://test.brave.com' ],
+            fingerprintingBlockedResources: [],
+            httpsRedirectedResources: [],
+            javascriptBlockedResources: []
           }
         },
         windows: {
-          1: 2
+            1: 2
         }
       })
     })
@@ -834,7 +912,12 @@ describe('braveShieldsPanelReducer', () => {
             ads: 'block',
             fingerprinting: 'block',
             cookies: 'block',
-            noScriptInfo: {}
+            noScriptInfo: {},
+            adsBlockedResources: [ 'https://test.brave.com' ],
+            fingerprintingBlockedResources: [],
+            httpsRedirectedResources: [],
+            javascriptBlockedResources: [],
+            trackersBlockedResources: []
           }
         },
         windows: {
@@ -850,6 +933,7 @@ describe('braveShieldsPanelReducer', () => {
           subresource: 'https://test.brave.com'
         }
       })
+
       assert.deepEqual(nextState, {
         currentWindowId: 1,
         tabs: {
@@ -870,13 +954,19 @@ describe('braveShieldsPanelReducer', () => {
             ads: 'block',
             fingerprinting: 'block',
             cookies: 'block',
-            noScriptInfo: {}
+            noScriptInfo: {},
+            trackersBlockedResources: [ 'https://test.brave.com' ],
+            adsBlockedResources: [ 'https://test.brave.com' ],
+            fingerprintingBlockedResources: [],
+            httpsRedirectedResources: [],
+            javascriptBlockedResources: []
           }
         },
         windows: {
           1: 2
         }
       })
+
       nextState = shieldsPanelReducer(nextState, {
         type: types.RESOURCE_BLOCKED,
         details: {
@@ -905,7 +995,12 @@ describe('braveShieldsPanelReducer', () => {
             ads: 'block',
             fingerprinting: 'block',
             cookies: 'block',
-            noScriptInfo: {}
+            noScriptInfo: {},
+            trackersBlockedResources: [ 'https://test.brave.com' ],
+            adsBlockedResources: [ 'https://test.brave.com' ],
+            fingerprintingBlockedResources: [],
+            httpsRedirectedResources: [ 'https://test.brave.com' ],
+            javascriptBlockedResources: []
           }
         },
         windows: {
@@ -942,7 +1037,12 @@ describe('braveShieldsPanelReducer', () => {
             cookies: 'block',
             noScriptInfo: {
               'https://test.brave.com/': { actuallyBlocked: true, willBlock: true }
-            }
+            },
+            trackersBlockedResources: [ 'https://test.brave.com' ],
+            adsBlockedResources: [ 'https://test.brave.com' ],
+            fingerprintingBlockedResources: [],
+            httpsRedirectedResources: [ 'https://test.brave.com' ],
+            javascriptBlockedResources: [ 'https://test.brave.com/index.js' ]
           }
         },
         windows: {
@@ -979,7 +1079,12 @@ describe('braveShieldsPanelReducer', () => {
             cookies: 'block',
             noScriptInfo: {
               'https://test.brave.com/': { actuallyBlocked: true, willBlock: true }
-            }
+            },
+            trackersBlockedResources: [ 'https://test.brave.com' ],
+            adsBlockedResources: [ 'https://test.brave.com' ],
+            fingerprintingBlockedResources: [ 'https://test.brave.com' ],
+            httpsRedirectedResources: [ 'https://test.brave.com' ],
+            javascriptBlockedResources: [ 'https://test.brave.com/index.js' ]
           }
         },
         windows: {
@@ -1085,7 +1190,12 @@ describe('braveShieldsPanelReducer', () => {
                 actuallyBlocked: true,
                 willBlock: true
               }
-            }
+            },
+            adsBlockedResources: [],
+            trackersBlockedResources: [],
+            httpsRedirectedResources: [],
+            javascriptBlockedResources: [],
+            fingerprintingBlockedResources: []
           }
         },
         windows: {
@@ -1122,7 +1232,12 @@ describe('braveShieldsPanelReducer', () => {
                 actuallyBlocked: true,
                 willBlock: false
               }
-            }
+            },
+            adsBlockedResources: [],
+            trackersBlockedResources: [],
+            httpsRedirectedResources: [],
+            javascriptBlockedResources: [],
+            fingerprintingBlockedResources: [],
           }
         },
         windows: {

--- a/test/app/components/braveShields/braveShieldsHeaderTest.tsx
+++ b/test/app/components/braveShields/braveShieldsHeaderTest.tsx
@@ -7,7 +7,7 @@ import 'mocha'
 import * as React from 'react'
 import * as assert from 'assert'
 import BraveShieldsHeader, { BraveShieldsHeaderProps } from '../../../../app/components/braveShields/braveShieldsHeader'
-import { BlockOptions } from '../../../../app/types/other/blockTypes';
+import { BlockOptions } from '../../../../app/types/other/blockTypes'
 import * as actionTypes from '../../../../app/constants/shieldsPanelTypes'
 import { shallow } from 'enzyme'
 import * as sinon from 'sinon'

--- a/test/app/components/braveShields/braveShieldsStatsTest.tsx
+++ b/test/app/components/braveShields/braveShieldsStatsTest.tsx
@@ -7,8 +7,9 @@ import 'mocha'
 import * as React from 'react'
 import * as assert from 'assert'
 import BraveShieldsStats from '../../../../app/components/braveShields/braveShieldsStats'
-import { BraveShieldsStatsProps } from '../../../../app/components/braveShields/braveShieldsStats';
+import { BraveShieldsStatsProps } from '../../../../app/components/braveShields/braveShieldsStats'
 import { shallow } from 'enzyme'
+// import * as sinon from 'sinon'
 
 const fakeProps: BraveShieldsStatsProps = {
   braveShields: 'allow',
@@ -16,7 +17,12 @@ const fakeProps: BraveShieldsStatsProps = {
   trackersBlocked: 2,
   httpsRedirected: 3,
   javascriptBlocked: 4,
-  fingerprintingBlocked: 5
+  fingerprintingBlocked: 5,
+  adsBlockedResources: [],
+  trackersBlockedResources: [],
+  httpsRedirectedResources: [],
+  javascriptBlockedResources: [],
+  fingerprintingBlockedResources: []
 }
 
 describe('BraveShieldsStats component', () => {
@@ -29,5 +35,190 @@ describe('BraveShieldsStats component', () => {
     assert.equal(assertion, true)
   })
 
-  // TODO: add more tests after #202
+  describe('stats for ads and trackers blocked', () => {
+    it('correctly displays stats info based on state of ads + trackers blocked', () => {
+      const newProps = Object.assign(fakeProps, { adsBlocked: 1007, trackersBlocked: 330 })
+      const wrapper = shallow(baseComponent(newProps))
+      const assertion = wrapper.find('#totalAdsTrackersBlockedStat').html().includes('1337')
+
+      assert.equal(assertion, true)
+    })
+
+    it('onClick event fires local state change for opening details', () => {
+      const componentId = 'totalAdsTrackersBlockedStat'
+      const target = { target: { id: componentId } }
+      const wrapper = shallow(baseComponent(fakeProps))
+      wrapper.find(`#${componentId}`).simulate('click', target)
+      const assertion = wrapper.state('adsTrackersBlockedDetailsOpen')
+
+      assert.equal(assertion, true)
+    })
+
+    it('onClick shows a list of blocked resources', () => {
+      const componentId = 'totalAdsTrackersBlockedStat'
+      const target = { target: { id: componentId } }
+      const newProps = Object.assign(fakeProps, {
+        adsBlockedResources: [
+          'https://anthony-beats-chuck-norris-in-everything.co.uk',
+          'https://in-fact-jocelyn-can-beat-anthony-very-easily.news'
+        ]
+      })
+      const wrapper = shallow(baseComponent(newProps))
+      wrapper.find(`#${componentId}`).simulate('click', target)
+      const assertion1 = wrapper.find('#blockedResourcesStats')
+        .html().includes('https://anthony-beats-chuck-norris-in-everything.co.uk')
+
+      // ONE CAN NOT BEAT ANTHONY. THIS TEST NEVER FAILS
+      assert.equal(assertion1, true)
+
+      // NEITHER THIS. WHAT A TEAM
+      const assertion2 = wrapper.find('#blockedResourcesStats')
+        .html().includes('https://in-fact-jocelyn-can-beat-anthony-very-easily.news')
+
+      assert.equal(assertion2, true)
+    })
+
+    it('properly merges ads + trackers in the same list', () => {
+      const componentId = 'totalAdsTrackersBlockedStat'
+      const target = { target: { id: componentId } }
+      const newProps = Object.assign(fakeProps, {
+        adsBlockedResources: ['https://george-clooney-was-born-same-day-as-cezar.biz'],
+        trackersBlockedResources: ['https://this-url-is-courtesy-of-too-much-nespresso.info']
+      })
+      const wrapper = shallow(baseComponent(newProps))
+      wrapper.find(`#${componentId}`).simulate('click', target)
+      const assertion1 = wrapper.find('#blockedResourcesStats')
+        .html().includes('https://george-clooney-was-born-same-day-as-cezar.biz')
+
+        assert.equal(assertion1, true)
+      const assertion2 = wrapper.find('#blockedResourcesStats')
+        .html().includes('https://this-url-is-courtesy-of-too-much-nespresso.info')
+
+      assert.equal(assertion2, true)
+    })
+  })
+
+  describe('stats for https redirected', () => {
+    it('correctly displays stats info based on state', () => {
+      const newProps = Object.assign(fakeProps, { httpsRedirected: 444 })
+      const wrapper = shallow(baseComponent(newProps))
+      const assertion = wrapper.find('#httpsRedirectedStat').html().includes('444')
+
+      assert.equal(assertion, true)
+    })
+
+    it('onClick event fires local state change for opening details', () => {
+      const componentId = 'httpsRedirectedStat'
+      const target = { target: { id: componentId } }
+      const wrapper = shallow(baseComponent(fakeProps))
+      wrapper.find(`#${componentId}`).simulate('click', target)
+      const assertion = wrapper.state('httpsRedirectedDetailsOpen')
+      assert.equal(assertion, true)
+    })
+
+    it('onClick shows a list of redirected resources', () => {
+      const componentId = 'httpsRedirectedStat'
+      const target = { target: { id: componentId } }
+      const newProps = Object.assign(fakeProps, {
+        httpsRedirectedResources: [
+          'https://serg-knows-a-few-pokemons.biz',
+          'https://serg-knows-charizard-and-all-dragon-pokemons.asia'
+        ]
+      })
+      const wrapper = shallow(baseComponent(newProps))
+      wrapper.find(`#${componentId}`).simulate('click', target)
+      const assertion1 = wrapper.find('#blockedResourcesStats')
+        .html().includes('https://serg-knows-a-few-pokemons.biz')
+
+      assert.equal(assertion1, true)
+
+      const assertion2 = wrapper.find('#blockedResourcesStats')
+        .html().includes('https://serg-knows-charizard-and-all-dragon-pokemons.asia')
+
+      assert.equal(assertion2, true)
+    })
+  })
+
+  describe('stats for javascript blocked', () => {
+    it('correctly displays stats info based on state', () => {
+      const newProps = Object.assign(fakeProps, { javascriptBlocked: 12123 })
+      const wrapper = shallow(baseComponent(newProps))
+      const assertion = wrapper.find('#javascriptBlockedStat').html().includes('12123')
+
+      assert.equal(assertion, true)
+    })
+
+    it('onClick event fires local state change for opening details', () => {
+      const componentId = 'javascriptBlockedStat'
+      const target = { target: { id: componentId } }
+      const wrapper = shallow(baseComponent(fakeProps))
+      wrapper.find(`#${componentId}`).simulate('click', target)
+      const assertion = wrapper.state('javascriptBlockedDetailsOpen')
+      assert.equal(assertion, true)
+    })
+
+    it('onClick shows a list of blocked resources', () => {
+      const componentId = 'javascriptBlockedStat'
+      const target = { target: { id: componentId } }
+      const newProps = Object.assign(fakeProps, {
+        javascriptBlockedResources: [
+          'https://brian-bondy-is-the-real-sub-zero-from-mortal-kombat.biz',
+          'https://brian-clifton-is-the-real-scorpion-from-mortal-kombat.biz'
+        ]
+      })
+      const wrapper = shallow(baseComponent(newProps))
+      wrapper.find(`#${componentId}`).simulate('click', target)
+      const assertion1 = wrapper.find('#blockedResourcesStats')
+        .html().includes('https://brian-bondy-is-the-real-sub-zero-from-mortal-kombat.biz')
+
+      assert.equal(assertion1, true)
+
+      const assertion2 = wrapper.find('#blockedResourcesStats')
+        .html().includes('https://brian-bondy-is-the-real-sub-zero-from-mortal-kombat.biz')
+
+      assert.equal(assertion2, true)
+    })
+  })
+
+  describe('stats for fingerprinting blocked', () => {
+    it('correctly displays stats info based on state', () => {
+      const newProps = Object.assign(fakeProps, { fingerprintingBlocked: 7777 })
+      const wrapper = shallow(baseComponent(newProps))
+      const assertion = wrapper.find('#fingerprintingBlockedStat').html().includes('7777')
+
+      assert.equal(assertion, true)
+    })
+
+    it('onClick event fires local state change for opening details', () => {
+      const componentId = 'fingerprintingBlockedStat'
+      const target = { target: { id: componentId } }
+      const wrapper = shallow(baseComponent(fakeProps))
+      wrapper.find(`#${componentId}`).simulate('click', target)
+      const assertion = wrapper.state('fingerprintingBlockedDetailsOpen')
+      assert.equal(assertion, true)
+    })
+
+    it('onClick shows a list of blocked resources', () => {
+      const componentId = 'fingerprintingBlockedStat'
+      const target = { target: { id: componentId } }
+      const newProps = Object.assign(fakeProps, {
+        fingerprintingBlockedResources: [
+          'https://this-fingerprinting-is-blocked.email',
+          'https://this-fingerprinting-didnt.work'
+        ]
+      })
+      const wrapper = shallow(baseComponent(newProps))
+      wrapper.find(`#${componentId}`).simulate('click', target)
+
+      const assertion1 = wrapper.find('#blockedResourcesStats')
+        .html().includes('https://this-fingerprinting-is-blocked.email')
+
+      assert.equal(assertion1, true)
+
+      const assertion2 = wrapper.find('#blockedResourcesStats')
+        .html().includes('https://this-fingerprinting-didnt.work')
+
+      assert.equal(assertion2, true)
+    })
+  })
 })

--- a/test/app/state/shieldsPanelStateTest.ts
+++ b/test/app/state/shieldsPanelStateTest.ts
@@ -7,7 +7,7 @@ import 'mocha'
 import * as assert from 'assert'
 import * as deepFreeze from 'deep-freeze-node'
 import * as shieldsPanelState from '../../../app/state/shieldsPanelState'
-import { State } from '../../../app/types/state/shieldsPannelState';
+import { State } from '../../../app/types/state/shieldsPannelState'
 
 const state: State = deepFreeze({
   currentWindowId: 1,
@@ -24,7 +24,7 @@ const state: State = deepFreeze({
     3: {
       id: 3
     },
-    4: {
+    4: { 
       id: 4
     }
   },
@@ -215,7 +215,12 @@ describe('shieldsPanelState test', () => {
             httpsRedirected: 0,
             javascriptBlocked: 0,
             fingerprintingBlocked: 0,
-            noScriptInfo: {}
+            noScriptInfo: {},
+            adsBlockedResources: [],
+            trackersBlockedResources: [],
+            httpsRedirectedResources: [],
+            javascriptBlockedResources: [],
+            fingerprintingBlockedResources: []
           },
           3: {
             id: 3
@@ -255,7 +260,12 @@ describe('shieldsPanelState test', () => {
             origin: 'https://brave.com',
             braveShields: 'block',
             url: 'https://brave.com',
-            noScriptInfo: {}
+            noScriptInfo: {},
+            adsBlockedResources: [],
+            trackersBlockedResources: [],
+            httpsRedirectedResources: [],
+            javascriptBlockedResources: [],
+            fingerprintingBlockedResources: []
           },
           3: {
             ads: 'block',
@@ -275,7 +285,12 @@ describe('shieldsPanelState test', () => {
             cookies: 'block',
             fingerprintingBlocked: 0,
             url: 'https://brave.com',
-            noScriptInfo: {}
+            noScriptInfo: {},
+            adsBlockedResources: [],
+            trackersBlockedResources: [],
+            httpsRedirectedResources: [],
+            javascriptBlockedResources: [],
+            fingerprintingBlockedResources: []
           },
           4: {
             ads: 'block',
@@ -295,7 +310,12 @@ describe('shieldsPanelState test', () => {
             cookies: 'block',
             fingerprintingBlocked: 0,
             url: 'https://brave.com',
-            noScriptInfo: {}
+            noScriptInfo: {},
+            adsBlockedResources: [],
+            trackersBlockedResources: [],
+            httpsRedirectedResources: [],
+            javascriptBlockedResources: [],
+            fingerprintingBlockedResources: []
           }
         },
         windows: {
@@ -330,7 +350,12 @@ describe('shieldsPanelState test', () => {
             origin: 'https://brave.com',
             braveShields: 'block',
             url: 'https://brave.com',
-            noScriptInfo: {}
+            noScriptInfo: {},
+            adsBlockedResources: [],
+            trackersBlockedResources: [],
+            httpsRedirectedResources: [],
+            javascriptBlockedResources: [],
+            fingerprintingBlockedResources: []
           },
           3: {
             ads: 'block',
@@ -350,7 +375,12 @@ describe('shieldsPanelState test', () => {
             cookies: 'block',
             fingerprintingBlocked: 0,
             url: 'https://brave.com',
-            noScriptInfo: {}
+            noScriptInfo: {},
+            adsBlockedResources: [],
+            trackersBlockedResources: [],
+            httpsRedirectedResources: [],
+            javascriptBlockedResources: [],
+            fingerprintingBlockedResources: []
           },
           4: {
             ads: 'block',
@@ -370,7 +400,12 @@ describe('shieldsPanelState test', () => {
             cookies: 'block',
             fingerprintingBlocked: 0,
             url: 'https://brave.com',
-            noScriptInfo: {}
+            noScriptInfo: {},
+            adsBlockedResources: [],
+            trackersBlockedResources: [],
+            httpsRedirectedResources: [],
+            javascriptBlockedResources: [],
+            fingerprintingBlockedResources: []
           }
         },
         windows: {
@@ -402,7 +437,12 @@ describe('shieldsPanelState test', () => {
             cookies: 'block',
             fingerprintingBlocked: 0,
             url: 'https://brave.com',
-            noScriptInfo: {}
+            noScriptInfo: {},
+            adsBlockedResources: [],
+            trackersBlockedResources: [],
+            httpsRedirectedResources: [],
+            javascriptBlockedResources: [],
+            fingerprintingBlockedResources: []
           },
           3: {
             ads: 'block',
@@ -422,7 +462,12 @@ describe('shieldsPanelState test', () => {
             cookies: 'block',
             fingerprintingBlocked: 0,
             url: 'https://brave.com',
-            noScriptInfo: {}
+            noScriptInfo: {},
+            adsBlockedResources: [],
+            trackersBlockedResources: [],
+            httpsRedirectedResources: [],
+            javascriptBlockedResources: [],
+            fingerprintingBlockedResources: []
           },
           4: {
             ads: 'block',
@@ -442,7 +487,12 @@ describe('shieldsPanelState test', () => {
             cookies: 'block',
             fingerprintingBlocked: 5,
             url: 'https://brave.com',
-            noScriptInfo: {}
+            noScriptInfo: {},
+            adsBlockedResources: [],
+            trackersBlockedResources: [],
+            httpsRedirectedResources: [],
+            javascriptBlockedResources: [],
+            fingerprintingBlockedResources: []
           }
         },
         windows: {
@@ -472,7 +522,12 @@ describe('shieldsPanelState test', () => {
             cookies: 'block',
             fingerprintingBlocked: 0,
             url: 'https://brave.com',
-            noScriptInfo: {}
+            noScriptInfo: {},
+            adsBlockedResources: [],
+            trackersBlockedResources: [],
+            httpsRedirectedResources: [],
+            javascriptBlockedResources: [],
+            fingerprintingBlockedResources: []
           },
           3: {
             ads: 'block',
@@ -492,7 +547,12 @@ describe('shieldsPanelState test', () => {
             cookies: 'block',
             fingerprintingBlocked: 0,
             url: 'https://brave.com',
-            noScriptInfo: {}
+            noScriptInfo: {},
+            adsBlockedResources: [],
+            trackersBlockedResources: [],
+            httpsRedirectedResources: [],
+            javascriptBlockedResources: [],
+            fingerprintingBlockedResources: []
           },
           4: {
             ads: 'block',
@@ -512,7 +572,12 @@ describe('shieldsPanelState test', () => {
             cookies: 'block',
             fingerprintingBlocked: 0,
             url: 'https://brave.com',
-            noScriptInfo: {}
+            noScriptInfo: {},
+            adsBlockedResources: [],
+            trackersBlockedResources: [],
+            httpsRedirectedResources: [],
+            javascriptBlockedResources: [],
+            fingerprintingBlockedResources: []
           }
         },
         windows: {
@@ -541,7 +606,12 @@ describe('shieldsPanelState test', () => {
             httpsRedirected: 0,
             javascriptBlocked: 0,
             fingerprintingBlocked: 0,
-            noScriptInfo: {}
+            noScriptInfo: {},
+            adsBlockedResources: [ 'https://test.brave.com' ],
+            fingerprintingBlockedResources: [],
+            httpsRedirectedResources: [],
+            javascriptBlockedResources: [],
+            trackersBlockedResources: []
           },
           3: {
             id: 3
@@ -574,7 +644,12 @@ describe('shieldsPanelState test', () => {
             httpsRedirected: 0,
             javascriptBlocked: 0,
             fingerprintingBlocked: 0,
-            noScriptInfo: {}
+            noScriptInfo: {},
+            adsBlockedResources: [],
+            fingerprintingBlockedResources: [],
+            httpsRedirectedResources: [],
+            javascriptBlockedResources: [],
+            trackersBlockedResources: [ 'https://test.brave.com' ]
           },
           3: {
             id: 3
@@ -609,7 +684,12 @@ describe('shieldsPanelState test', () => {
             fingerprintingBlocked: 0,
             noScriptInfo: {
               'https://test.brave.com/': { actuallyBlocked: true, willBlock: true }
-            }
+            },
+            adsBlockedResources: [],
+            fingerprintingBlockedResources: [],
+            httpsRedirectedResources: [],
+            javascriptBlockedResources: [ 'https://test.brave.com' ],
+            trackersBlockedResources: []
           },
           3: {
             id: 3
@@ -650,7 +730,12 @@ describe('shieldsPanelState test', () => {
           noScriptInfo: {
             'https://a.com': { actuallyBlocked: true, willBlock: true },
             'https://b.com': { actuallyBlocked: false, willBlock: false }
-          }
+          },
+          adsBlockedResources: [],
+          trackersBlockedResources: [],
+          httpsRedirectedResources: [],
+          javascriptBlockedResources: [],
+          fingerprintingBlockedResources: []
         },
         3: {
           id: 3,
@@ -673,7 +758,12 @@ describe('shieldsPanelState test', () => {
           noScriptInfo: {
             'https://a.com': { actuallyBlocked: true, willBlock: true },
             'https://b.com': { actuallyBlocked: false, willBlock: false }
-          }
+          },
+          adsBlockedResources: [],
+          trackersBlockedResources: [],
+          httpsRedirectedResources: [],
+          javascriptBlockedResources: [],
+          fingerprintingBlockedResources: []
         }
       },
       windows: {
@@ -708,7 +798,12 @@ describe('shieldsPanelState test', () => {
               noScriptInfo: {
                 'https://a.com': { actuallyBlocked: false, willBlock: true },
                 'https://b.com': { actuallyBlocked: false, willBlock: false }
-              }
+              },
+              adsBlockedResources: [],
+              trackersBlockedResources: [],
+              httpsRedirectedResources: [],
+              javascriptBlockedResources: [],
+              fingerprintingBlockedResources: []
             },
             3: {
               id: 3,
@@ -731,7 +826,12 @@ describe('shieldsPanelState test', () => {
               noScriptInfo: {
                 'https://a.com': { actuallyBlocked: true, willBlock: true },
                 'https://b.com': { actuallyBlocked: false, willBlock: false }
-              }
+              },
+              adsBlockedResources: [],
+              trackersBlockedResources: [],
+              httpsRedirectedResources: [],
+              javascriptBlockedResources: [],
+              fingerprintingBlockedResources: []
             }
           },
           windows: {
@@ -764,7 +864,12 @@ describe('shieldsPanelState test', () => {
               cookies: 'block',
               fingerprintingBlocked: 0,
               url: 'https://brave.com',
-              noScriptInfo: {}
+              noScriptInfo: {},
+              adsBlockedResources: [],
+              trackersBlockedResources: [],
+              httpsRedirectedResources: [],
+              javascriptBlockedResources: [],
+              fingerprintingBlockedResources: []
             },
             3: {
               id: 3,
@@ -787,7 +892,12 @@ describe('shieldsPanelState test', () => {
               noScriptInfo: {
                 'https://a.com': { actuallyBlocked: true, willBlock: true },
                 'https://b.com': { actuallyBlocked: false, willBlock: false }
-              }
+              },
+              adsBlockedResources: [],
+              trackersBlockedResources: [],
+              httpsRedirectedResources: [],
+              javascriptBlockedResources: [],
+              fingerprintingBlockedResources: []
             }
           },
           windows: {

--- a/test/testData.ts
+++ b/test/testData.ts
@@ -3,7 +3,7 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import * as deepFreeze from 'deep-freeze-node'
-import { Tab } from '../app/types/state/shieldsPannelState';
+import { Tab } from '../app/types/state/shieldsPannelState'
 
 interface CustomTab extends Tab {
   url: string
@@ -32,7 +32,12 @@ export const tabs: Tabs = {
     fingerprintingBlocked: 0,
     braveShields: 'block',
     trackersBlocked: 0,
-    noScriptInfo: {}
+    noScriptInfo: {},
+    adsBlockedResources: [],
+    trackersBlockedResources: [],
+    httpsRedirectedResources: [],
+    javascriptBlockedResources: [],
+    fingerprintingBlockedResources: []
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1318,9 +1318,9 @@ braces@^2.3.0, braces@^2.3.1:
     split-string "^3.0.2"
     to-regex "^3.0.1"
 
-brave-ui@^0.10.5:
-  version "0.10.5"
-  resolved "https://registry.yarnpkg.com/brave-ui/-/brave-ui-0.10.5.tgz#64b69323b5f188bd7b0325ce3cb26fa6492415ee"
+brave-ui@^0.10.11:
+  version "0.10.11"
+  resolved "https://registry.yarnpkg.com/brave-ui/-/brave-ui-0.10.11.tgz#0480f3891c24779bc07caf2092a19d6856845fd6"
   dependencies:
     emptykit.css "^1.0.1"
     styled-components "^3.2.6"


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/202

**Test plan:**

1. `yarn test-unit` as several tests changed
2. `yarn test-unit -- --grep="braveShieldsStats component"` for component changes
3. `yarn test-unit -- --grep="RESOURCES_BLOCKED"` for state changes

**Manual test plan:**

1. Clicking over stats should show a list of blocked resources if any

<img width="295" alt="screen shot 2018-06-15 at 1 36 17 am" src="https://user-images.githubusercontent.com/4672033/41452583-f2efe60c-7048-11e8-85a8-2bb0810a7719.png">
