### PR TITLE
minor shields improvements

### DIFF
--- a/app/components/braveShields/braveShieldsControls.tsx
+++ b/app/components/braveShields/braveShieldsControls.tsx
@@ -95,6 +95,7 @@ export default class BraveShieldsControls extends React.Component<BraveShieldsCo
             <BoxedContent theme={theme.braveShieldsControlsContent}>
               <SelectOption
                 id='shieldsControlsAdControl'
+                theme={theme.noUserSelect}
                 disabled={braveShields === 'block'}
                 titleName={getMessage('shieldsControlsAdControl')}
                 value={braveShields !== 'block' && ads !== 'allow' && trackers !== 'allow' ? 'allow' : 'block'}
@@ -107,6 +108,7 @@ export default class BraveShieldsControls extends React.Component<BraveShieldsCo
 
               <SelectOption
                 id='shieldsControlsCookieControl'
+                theme={theme.noUserSelect}
                 disabled={braveShields === 'block'}
                 titleName={getMessage('shieldsControlsCookieControl')}
                 value={braveShields !== 'block' ? cookies : 'allow'}
@@ -119,6 +121,7 @@ export default class BraveShieldsControls extends React.Component<BraveShieldsCo
 
               <SelectOption
                 id='shieldsControlsFingerprintingProtection'
+                theme={theme.noUserSelect}
                 disabled={braveShields === 'block'}
                 titleName={getMessage('shieldsControlsFingerprintingProtection')}
                 value={braveShields !== 'block' ? fingerprinting : 'allow'}
@@ -134,6 +137,7 @@ export default class BraveShieldsControls extends React.Component<BraveShieldsCo
                   {/* TODO @cezaraugusto */}
                   <SwitchButton
                     id='httpsEverywhere'
+                    theme={theme.noUserSelect}
                     disabled={braveShields === 'block'}
                     rightText={getMessage('shieldsControlsHttpsEverywhereSwitch')}
                     checked={braveShields !== 'block' && httpUpgradableResources !== 'allow'}
@@ -144,6 +148,7 @@ export default class BraveShieldsControls extends React.Component<BraveShieldsCo
                   {/* TODO @cezaraugusto */}
                   <SwitchButton
                     id='blockScripts'
+                    theme={theme.noUserSelect}
                     disabled={braveShields === 'block'}
                     rightText={getMessage('shieldsControlsBlockScriptsSwitch')}
                     checked={braveShields !== 'block' && javascript !== 'allow'}
@@ -154,6 +159,7 @@ export default class BraveShieldsControls extends React.Component<BraveShieldsCo
                   {/* TODO @cezaraugusto */}
                   <SwitchButton
                     id='blockPhishingMalware'
+                    theme={theme.noUserSelect}
                     checked={false}
                     disabled={braveShields === 'block'}
                     rightText={getMessage('shieldsControlsBlockPhishingMalwareSwitch')}

--- a/app/components/braveShields/braveShieldsFooter.tsx
+++ b/app/components/braveShields/braveShieldsFooter.tsx
@@ -22,7 +22,7 @@ export default class BraveShieldsFooter extends React.PureComponent<{}, {}> {
           />
         </Column>
         <Column size={3} theme={theme.columnEnd}>
-          <UnstyledButton text={getMessage('shieldsFooterReload')} />
+          <UnstyledButton theme={theme.noUserSelect} text={getMessage('shieldsFooterReload')} />
         </Column>
       </Grid>
     )

--- a/app/components/braveShields/braveShieldsStats.tsx
+++ b/app/components/braveShields/braveShieldsStats.tsx
@@ -107,11 +107,19 @@ export default class BraveShieldsStats extends React.Component<BraveShieldsStats
   }
 
   onToggleBlockedResourcesDetails (e: any) {
+    const id = e.target.id || ''
+    const {
+      adsTrackersBlockedDetailsOpen,
+      httpsRedirectedDetailsOpen,
+      javascriptBlockedDetailsOpen,
+      fingerprintingBlockedDetailsOpen
+    } = this.state
+
     this.setState({
-      adsTrackersBlockedDetailsOpen: e.target.id.startsWith('totalAdsTrackersBlocked'),
-      httpsRedirectedDetailsOpen: e.target.id.startsWith('httpsRedirected'),
-      javascriptBlockedDetailsOpen: e.target.id.startsWith('javascriptBlocked'),
-      fingerprintingBlockedDetailsOpen: e.target.id.startsWith('fingerprintingBlocked')
+      adsTrackersBlockedDetailsOpen: id.startsWith('totalAdsTrackersBlocked') && !adsTrackersBlockedDetailsOpen,
+      httpsRedirectedDetailsOpen: id.startsWith('httpsRedirected') && !httpsRedirectedDetailsOpen,
+      javascriptBlockedDetailsOpen: id.startsWith('javascriptBlocked') && !javascriptBlockedDetailsOpen,
+      fingerprintingBlockedDetailsOpen: id.startsWith('fingerprintingBlocked') && !fingerprintingBlockedDetailsOpen
     })
   }
 

--- a/app/theme.ts
+++ b/app/theme.ts
@@ -52,7 +52,8 @@ const theme = {
     justifyContent: 'flex-end'
   },
   editLink: {
-    textDecoration: 'none'
+    textDecoration: 'none',
+    userSelect: 'none'
   },
   braveShieldsStats: {
     padding: '10px 15px',
@@ -118,6 +119,9 @@ const theme = {
   blockedResourcesStatsText: {
     fontSize: '10px',
     margin: '0 0 3px'
+  },
+  noUserSelect: {
+    userSelect: 'none'
   }
 }
 

--- a/app/theme.ts
+++ b/app/theme.ts
@@ -69,34 +69,42 @@ const theme = {
   totalAdsTrackersBlockedStat: {
     fontSize: '26px',
     color: '#fe521d',
-    lineHeight: '30px'
+    lineHeight: '30px',
+    cursor: 'pointer'
   },
   totalAdsTrackersBlockedText: {
-    lineHeight: '30px'
+    lineHeight: '30px',
+    cursor: 'pointer'
   },
   httpsRedirectedStat: {
     fontSize: '26px',
     color: '#0796fa',
-    lineHeight: '30px'
+    lineHeight: '30px',
+    cursor: 'pointer'
   },
   httpsRedirectedText: {
-    lineHeight: '30px'
+    lineHeight: '30px',
+    cursor: 'pointer'
   },
   javascriptBlockedStat: {
     fontSize: '26px',
     color: '#555555',
-    lineHeight: '30px'
+    lineHeight: '30px',
+    cursor: 'pointer'
   },
   javascriptBlockedText: {
-    lineHeight: '30px'
+    lineHeight: '30px',
+    cursor: 'pointer'
   },
   fingerprintingBlockedStat: {
     fontSize: '26px',
     color: '#ffc000',
-    lineHeight: '30px'
+    lineHeight: '30px',
+    cursor: 'pointer'
   },
   fingerprintingBlockedText: {
-    lineHeight: '30px'
+    lineHeight: '30px',
+    cursor: 'pointer'
   },
   noScript: {
     padding: '10px 0',
@@ -104,7 +112,8 @@ const theme = {
   },
   blockedResourcesStats: {
     flexDirection: 'column',
-    overflow: 'hidden'
+    overflow: 'hidden',
+    cursor: 'pointer'
   },
   blockedResourcesStatsText: {
     fontSize: '10px',

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
   "dependencies": {
     "@types/selenium-webdriver": "^3.0.8",
     "bluebird": "^3.5.1",
-    "brave-ui": "^0.10.12",
+    "brave-ui": "^0.10.13",
     "classnames": "^2.2.5",
     "deep-freeze-node": "^1.1.3",
     "enzyme": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
   "dependencies": {
     "@types/selenium-webdriver": "^3.0.8",
     "bluebird": "^3.5.1",
-    "brave-ui": "^0.10.11",
+    "brave-ui": "^0.10.12",
     "classnames": "^2.2.5",
     "deep-freeze-node": "^1.1.3",
     "enzyme": "^3.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1318,9 +1318,9 @@ braces@^2.3.0, braces@^2.3.1:
     split-string "^3.0.2"
     to-regex "^3.0.1"
 
-brave-ui@^0.10.11:
-  version "0.10.11"
-  resolved "https://registry.yarnpkg.com/brave-ui/-/brave-ui-0.10.11.tgz#0480f3891c24779bc07caf2092a19d6856845fd6"
+brave-ui@^0.10.12:
+  version "0.10.12"
+  resolved "https://registry.yarnpkg.com/brave-ui/-/brave-ui-0.10.12.tgz#b23b5d1bed13f023bf61462c8186f67386885d17"
   dependencies:
     emptykit.css "^1.0.1"
     styled-components "^3.2.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1318,9 +1318,9 @@ braces@^2.3.0, braces@^2.3.1:
     split-string "^3.0.2"
     to-regex "^3.0.1"
 
-brave-ui@^0.10.12:
-  version "0.10.12"
-  resolved "https://registry.yarnpkg.com/brave-ui/-/brave-ui-0.10.12.tgz#b23b5d1bed13f023bf61462c8186f67386885d17"
+brave-ui@^0.10.13:
+  version "0.10.13"
+  resolved "https://registry.yarnpkg.com/brave-ui/-/brave-ui-0.10.13.tgz#dd932f9076b3082524769d4c9a539b83ad28976b"
   dependencies:
     emptykit.css "^1.0.1"
     styled-components "^3.2.6"


### PR DESCRIPTION
follow-up of #35 
fix https://github.com/brave/brave-browser/issues/319

**Test Plan:**
(for #35)

* in shields, click on blocked stats twice should toggle on/off state and show/hide resources blocked
* above feature should have the pointer cursor

**Test Plan:**
(for https://github.com/brave/brave-browser/issues/319)

* No text inside shields should be selectable (not applicable to blocked resources URLs)