### PR TITLE
fix shields nor shrinking when advanced opt is hidden

### DIFF
--- a/app/views/braveShieldsPanel.pug
+++ b/app/views/braveShieldsPanel.pug
@@ -8,7 +8,6 @@ html
     link(rel='stylesheet', href=env == 'prod' ? '/bravelizer.css' : 'chrome-extension://mnojpmjdmbbfmejpflffifhffcmidifd/bravelizer.css')
     style.
       body {
-        height: 587px; /* 600px is the max allowed chrome extension height */
         width: 280px;
       }
 


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/53

**Test Plan:**

1. Toggle `Advanced Options` in shields
2. Extension should update its height based on its content (no extra whitespace at the bottom)