### PR TITLE
do not allow showing resources blocked if there's none

### DIFF
--- a/app/components/braveShields/braveShieldsStats.tsx
+++ b/app/components/braveShields/braveShieldsStats.tsx
@@ -88,13 +88,13 @@ export default class BraveShieldsStats extends React.Component<BraveShieldsStats
       fingerprintingBlockedDetailsOpen
     } = this.state
 
-    if (adsTrackersBlockedDetailsOpen) {
+    if (adsTrackersBlockedDetailsOpen && this.totalAdsTrackersBlocked > 0) {
       return this.setResourceBlockedItemView(this.totalAdsTrackersBlockedResources)
-    } else if (httpsRedirectedDetailsOpen) {
+    } else if (httpsRedirectedDetailsOpen && this.httpsRedirected > 0) {
       return this.setResourceBlockedItemView(this.httpsRedirectedResources)
-    } else if (javascriptBlockedDetailsOpen) {
+    } else if (javascriptBlockedDetailsOpen && this.javascriptBlocked > 0) {
       return this.setResourceBlockedItemView(this.javascriptBlockedResources)
-    } else if (fingerprintingBlockedDetailsOpen) {
+    } else if (fingerprintingBlockedDetailsOpen && this.fingerprintingBlocked > 0) {
       return this.setResourceBlockedItemView(this.fingerprintingBlockedResources)
     } else {
       return null


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/419
fix https://github.com/brave/brave-browser/issues/429

**Test Plan #1:** (as described in https://github.com/brave/brave-browser/issues/419)

1. Visit wikipedia.org in a new tab
2. Ensure shields shows badge as 0
3. Open shields, you can click on all shields stats even though it shows 0 **but it should not show any resource blocked as there's none**.

**Test Plan #2:** (as described in https://github.com/brave/brave-browser/issues/429)

1. Visit icloud.com in a new tab and change to Block all fingerprinting
2. See blocked count in shields
3. Visit nytimes.com in the same tab
4. Ensure there are no fingerprint blocked items
5. Click on 0 Fingerprint blocked,. **should not show any resource blocked as there's none**
