### PR TITLE
do not show badge text if there are no resources blocked

### DIFF
--- a/app/background/reducers/shieldsPanelReducer.ts
+++ b/app/background/reducers/shieldsPanelReducer.ts
@@ -29,7 +29,8 @@ const updateBadgeText = (state: State) => {
   const tab: Tab = state.tabs[tabId]
   if (tab) {
     const total = tab.adsBlocked + tab.trackersBlocked + tab.javascriptBlocked + tab.fingerprintingBlocked + tab.httpsRedirected
-    setBadgeText(total.toString())
+    // do not show any badge if there are no blocked items
+    setBadgeText(total > 0 ? total.toString() : '')
   }
 }
 


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/470

Test Plan:

1. websites with resources blocked should show browserAction badge icon
2. websites without resources blocked should not show the browserAction badge. i.e. about pages