### PR TITLE
disable shields for any protocol other than http or https

### DIFF
--- a/app/background/api/browserActionAPI.ts
+++ b/app/background/api/browserActionAPI.ts
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { isHttpOrHttps } from '../../helpers/urlUtils'
+
 /**
  * Sets the badge text
  * @param {string} text - The text to put on the badge
@@ -18,11 +20,10 @@ export const setBadgeText = (text: string) => {
 export const setIcon = (url: string, tabId: number, shieldsOn: boolean) => {
   const shieldsEnabledIcon = 'img/icon-16.png'
   const shieldsDisabledIcon = 'img/icon-16-disabled.png'
-  const isHttpOrHttps = url && /^http/.test(url)
 
   if (chrome.browserAction) {
     chrome.browserAction.setIcon({
-      path: shieldsOn && isHttpOrHttps ? shieldsEnabledIcon : shieldsDisabledIcon,
+      path: shieldsOn && isHttpOrHttps(url) ? shieldsEnabledIcon : shieldsDisabledIcon,
       tabId
     })
   }

--- a/app/background/api/shieldsAPI.ts
+++ b/app/background/api/shieldsAPI.ts
@@ -5,6 +5,7 @@
 import { Tab } from '../../types/state/shieldsPannelState'
 import { BlockOptions } from '../../types/other/blockTypes'
 import * as resourceIdentifiers from '../../constants/resourceIdentifiers'
+import { isHttpOrHttps } from '../../helpers/urlUtils'
 
 /**
  * Obtains the shields panel data for the specified tab data
@@ -33,12 +34,13 @@ export const getShieldSettingsForTabData = (tabData?: chrome.tabs.Tab) => {
   ]).then((details) => {
     const fingerprinting = details[5].setting !== details[6].setting ? 'block_third_party' : details[5].setting
     const cookies = details[7].setting !== details[8].setting ? 'block_third_party' : details[7].setting
+    const braveShields = isHttpOrHttps(origin) ? details[0].setting : 'block'
     return {
       url: url.href,
       origin,
       hostname,
       id: tabData.id,
-      braveShields: details[0].setting,
+      braveShields,
       ads: details[1].setting,
       trackers: details[2].setting,
       httpUpgradableResources: details[3].setting,

--- a/app/components/braveShields/braveShields.tsx
+++ b/app/components/braveShields/braveShields.tsx
@@ -39,6 +39,7 @@ export default class BraveShields extends React.Component<BraveShieldsProps, {}>
           braveShields={shieldsPanelTabData.braveShields}
           shieldsToggled={actions.shieldsToggled}
           hostname={shieldsPanelTabData.hostname}
+          origin={shieldsPanelTabData.origin}
         />
         <BraveShieldsStats
           braveShields={shieldsPanelTabData.braveShields}

--- a/app/components/braveShields/braveShieldsControls.tsx
+++ b/app/components/braveShields/braveShieldsControls.tsx
@@ -134,7 +134,6 @@ export default class BraveShieldsControls extends React.Component<BraveShieldsCo
 
               <Grid theme={theme.braveShieldsControlsSwitches}>
                 <Column>
-                  {/* TODO @cezaraugusto */}
                   <SwitchButton
                     id='httpsEverywhere'
                     theme={theme.noUserSelect}
@@ -145,7 +144,6 @@ export default class BraveShieldsControls extends React.Component<BraveShieldsCo
                   />
                 </Column>
                 <Column>
-                  {/* TODO @cezaraugusto */}
                   <SwitchButton
                     id='blockScripts'
                     theme={theme.noUserSelect}
@@ -156,7 +154,6 @@ export default class BraveShieldsControls extends React.Component<BraveShieldsCo
                   />
                 </Column>
                 <Column>
-                  {/* TODO @cezaraugusto */}
                   <SwitchButton
                     id='blockPhishingMalware'
                     theme={theme.noUserSelect}

--- a/app/components/braveShields/braveShieldsHeader.tsx
+++ b/app/components/braveShields/braveShieldsHeader.tsx
@@ -12,9 +12,11 @@ import * as shieldActions from '../../types/actions/shieldsPanelActions'
 import { BlockOptions } from '../../types/other/blockTypes'
 import { getMessage } from '../../background/api/localeAPI'
 import theme from '../../theme'
+import { isHttpOrHttps } from '../../helpers/urlUtils'
 
 export interface BraveShieldsHeaderProps {
   shieldsToggled: shieldActions.ShieldsToggled
+  origin: string
   hostname: string
   braveShields: BlockOptions
 }
@@ -27,6 +29,10 @@ export default class BraveShieldsHeader extends React.PureComponent<BraveShields
   }
 
   onToggleShields (e: HTMLSelectElement) {
+    const { origin } = this.props
+    if (!isHttpOrHttps(origin)) {
+      return
+    }
     const shieldsOption: BlockOptions = e.target.checked ? 'allow' : 'block'
     this.props.shieldsToggled(shieldsOption)
   }

--- a/app/helpers/urlUtils.ts
+++ b/app/helpers/urlUtils.ts
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export const isHttpOrHttps = (url?: string) => {
+  if (!url) {
+    return false
+  }
+  return /^https?:/i.test(url)
+}

--- a/test/app/background/api/shieldsAPITest.ts
+++ b/test/app/background/api/shieldsAPITest.ts
@@ -11,7 +11,7 @@ import * as shieldsAPI from '../../../../app/background/api/shieldsAPI'
 import { activeTabData } from '../../../testData'
 import { Tab as TabType } from '../../../../app/types/state/shieldsPannelState'
 import * as resourceIdentifiers from '../../../../app/constants/resourceIdentifiers'
-
+ 
 describe('Shields API', () => {
   describe('getShieldSettingsForTabData', function () {
     it('returns a rejected promise when no tab data is specified', function (cb) {
@@ -48,6 +48,75 @@ describe('Shields API', () => {
           cookies: 'block',
           id: 5
         })
+        cb()
+      })
+      .catch((e: Error) => {
+        console.error(e.toString())
+      })
+    })
+
+    it('returns `block` by default for braveShields when origin is either http or https', function (cb) {
+      const tab: chrome.tabs.Tab = {
+        url: 'https://www.brave.com/charizard/knows/serg',
+        index: 1,
+        pinned: false,
+        highlighted: false,
+        windowId: 1,
+        active: true,
+        incognito: false,
+        selected: false,
+        id: 1337
+      }
+
+      shieldsAPI.getShieldSettingsForTabData(tab).then((data) => {
+        const assertion = 'braveShields' in data && data.braveShields === 'block'
+        assert(assertion)
+        cb()
+      })
+      .catch((e: Error) => {
+        console.error(e.toString())
+      })
+    })
+
+    it('returns `block` by default for braveShields when origin is not http or https', function (cb) {
+      const tab: chrome.tabs.Tab = {
+        url: 'ftp://www.brave.com/serg/dont/know/pikachu',
+        index: 1,
+        pinned: false,
+        highlighted: false,
+        windowId: 1,
+        active: true,
+        incognito: false,
+        selected: false,
+        id: 1337
+      }
+
+      shieldsAPI.getShieldSettingsForTabData(tab).then((data) => {
+        const assertion = 'braveShields' in data && data.braveShields === 'block'
+        assert(assertion)
+        cb()
+      })
+      .catch((e: Error) => {
+        console.error(e.toString())
+      })
+    })
+
+    it('returns `block` by default for braveShields when origin is an about page', function (cb) {
+      const tab: chrome.tabs.Tab = {
+        url: 'chrome://welcome',
+        index: 1,
+        pinned: false,
+        highlighted: false,
+        windowId: 1,
+        active: true,
+        incognito: false,
+        selected: false,
+        id: 1337
+      }
+
+      shieldsAPI.getShieldSettingsForTabData(tab).then((data) => {
+        const assertion = 'braveShields' in data && data.braveShields === 'block'
+        assert(assertion)
         cb()
       })
       .catch((e: Error) => {

--- a/test/app/components/braveShields/braveShieldsHeaderTest.tsx
+++ b/test/app/components/braveShields/braveShieldsHeaderTest.tsx
@@ -14,6 +14,7 @@ import * as sinon from 'sinon'
 
 const fakeProps: BraveShieldsHeaderProps = {
   hostname: 'brave.com',
+  origin: 'https://brave.com',
   shieldsToggled: (setting: BlockOptions) => {
     return {
       type: actionTypes.SHIELDS_TOGGLED,

--- a/test/app/helpers/urlUtilsTest.ts
+++ b/test/app/helpers/urlUtilsTest.ts
@@ -1,0 +1,44 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import 'mocha'
+import * as assert from 'assert'
+import { isHttpOrHttps } from '../../../app/helpers/urlUtils'
+
+describe('urlUtils test', function () {
+  describe('isHttpOrHttps', function () {
+    it('matches http when defined as a protocol type', function () {
+      const url = 'http://some-boring-unsafe-website.com'
+      assert.equal(isHttpOrHttps(url), true)
+    })
+    it('matches https when defined as a protocol type', function () {
+      const url = 'https://some-nice-safe-website.com'
+      assert.equal(isHttpOrHttps(url), true)
+    })
+    it('does not match http when defined as an origin', function () {
+      const url = 'file://http.some-website-tricking-you.com'
+      assert.equal(isHttpOrHttps(url), false)
+    })
+    it('does not match https when defined as an origin', function () {
+      const url = 'file://https.some-website-tricking-you.com'
+      assert.equal(isHttpOrHttps(url), false)
+    })
+    it('does not match other protocol', function () {
+      const url = 'ftp://some-old-website.com'
+      assert.equal(isHttpOrHttps(url), false)
+    })
+    it('does not match when url is not defined', function () {
+      const url = undefined
+      assert.equal(isHttpOrHttps(url), false)
+    })
+    it('matches uppercase http', function () {
+      const url = 'HTTP://SCREAMING-SAFE-WEBSITE.COM'
+      assert.equal(isHttpOrHttps(url), true)
+    })
+    it('matches uppercase https', function () {
+      const url = 'HTTP://SCREAMING-UNSAFE-WEBSITE.COM'
+      assert.equal(isHttpOrHttps(url), true)
+    })
+  })
+})


### PR DESCRIPTION
fix brave/brave-browser#169

Test Plan:

covered by automated tests

Manual Test Plan:

Any website using protocols other than `http://`/`https://` such as `chrome://` or `file://` should have shields disabled without the option to enable it