### PR TITLE
Remove Flickering and Fix Context Menu Display

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -13,6 +13,7 @@ action("brave-extension") {
   outputs = [
     "$target_gen_dir/brave_extension/build/background.html",
     "$target_gen_dir/brave_extension/build/js/background.bundle.js",
+    "$target_gen_dir/brave_extension/build/js/content.bundle.js",
     "$target_gen_dir/brave_extension/build/js/braveShieldsPanel.bundle.js",
     "$target_gen_dir/brave_extension/build/braveShieldsPanel.html",
     "$target_gen_dir/brave_extension/build/bravelizer.css",

--- a/app/background/api/cosmeticFilterAPI.ts
+++ b/app/background/api/cosmeticFilterAPI.ts
@@ -24,7 +24,8 @@ export const applySiteFilters = (hostname: string) => {
       storeData.cosmeticFilterList[hostname].map((rule: string) => {
         console.log('applying rule', rule)
         chrome.tabs.insertCSS({
-          code: `${rule} {display: none;}`
+          code: `${rule} {display: none;}`,
+          runAt: 'document_start'
         })
       })
     }

--- a/app/background/events/cosmeticFilterEvents.ts
+++ b/app/background/events/cosmeticFilterEvents.ts
@@ -5,33 +5,30 @@ let rule = {
   selector: ''
 }
 
-// add context menu
-chrome.runtime.onInstalled.addListener(function () {
-  // parent menu
-  chrome.contextMenus.create({
-    title: 'Brave',
-    id: 'brave',
-    contexts: ['all']
-  })
-  // block ad child menu
-  chrome.contextMenus.create({
-    title: 'Block element via selector',
-    id: 'addBlockElement',
-    parentId: 'brave',
-    contexts: ['all']
-  })
-  chrome.contextMenus.create({
-    title: 'Clear CSS rules for this site',
-    id: 'resetSiteFilterSettings',
-    parentId: 'brave',
-    contexts: ['all']
-  })
-  chrome.contextMenus.create({
-    title: 'Clear CSS rules for all sites',
-    id: 'resetAllFilterSettings',
-    parentId: 'brave',
-    contexts: ['all']
-  })
+// parent menu
+chrome.contextMenus.create({
+  title: 'Brave',
+  id: 'brave',
+  contexts: ['all']
+})
+// block ad child menu
+chrome.contextMenus.create({
+  title: 'Block element via selector',
+  id: 'addBlockElement',
+  parentId: 'brave',
+  contexts: ['all']
+})
+chrome.contextMenus.create({
+  title: 'Clear CSS rules for this site',
+  id: 'resetSiteFilterSettings',
+  parentId: 'brave',
+  contexts: ['all']
+})
+chrome.contextMenus.create({
+  title: 'Clear CSS rules for all sites',
+  id: 'resetAllFilterSettings',
+  parentId: 'brave',
+  contexts: ['all']
 })
 
 // contextMenu listener - when triggered, grab latest selector

--- a/test/app/background/api/cosmeticFilterAPITest.ts
+++ b/test/app/background/api/cosmeticFilterAPITest.ts
@@ -184,7 +184,8 @@ describe('cosmeticFilterTestSuite', () => {
       })
       cosmeticFilterAPI.applySiteFilters('brave.com')
       assert.deepEqual(this.insertCSSStub.getCall(0).args[0], {
-        code: `${filter} {display: none;}`
+        code: `${filter} {display: none;}`,
+        runAt: 'document_start'
       })
     })
     it('applies multiple filters correctly', function () {
@@ -195,10 +196,12 @@ describe('cosmeticFilterTestSuite', () => {
       })
       cosmeticFilterAPI.applySiteFilters('brave.com')
       assert.deepEqual(this.insertCSSStub.getCall(0).args[0], {
-        code: `${filter} {display: none;}`
+        code: `${filter} {display: none;}`,
+        runAt: 'document_start'
       })
       assert.deepEqual(this.insertCSSStub.getCall(1).args[0], {
-        code: `${filter2} {display: none;}`
+        code: `${filter2} {display: none;}`,
+        runAt: 'document_start'
       })
 
     })


### PR DESCRIPTION
Status: Ready to be merged.

Specifying for things to `runAt: document_start` in the `manifest.json` is not sufficient, each `chrome.tabs.insertCSS` call must include the `runAt` property as well. 

Otherwise, it will default to `document_idle`. This causes flickering.

Read more here: https://developer.chrome.com/extensions/tabs

I'm not sure if I should be merging the huge `package-lock.json` file, but I did a rebase off of `brave/brave-extension:master` and a fresh `npm i`. Please let me know if I should not check this in.

To include in this PR:

- [ ] change DEPS
- [x] fix BUILD.gn
- [x] amend tests
- [x] remove package-lock.json
- [x] change `runAt` property to `document_start`