### PR TITLE
Handle no active tab in state and no cosmetic filter list in storage

### DIFF
--- a/app/background/api/cosmeticFilterAPI.ts
+++ b/app/background/api/cosmeticFilterAPI.ts
@@ -20,6 +20,10 @@ export const removeSiteFilter = (origin: string) => {
 
 export const applySiteFilters = (hostname: string) => {
   chrome.storage.local.get('cosmeticFilterList', (storeData = {}) => {
+    if (!storeData.cosmeticFilterList) {
+      console.info('applySiteFilters: no cosmetic filter store yet')
+      return
+    }
     if (storeData.cosmeticFilterList[hostname] !== undefined) {
       storeData.cosmeticFilterList[hostname].map((rule: string) => {
         console.log('applying rule', rule)

--- a/app/background/reducers/cosmeticFilterReducer.ts
+++ b/app/background/reducers/cosmeticFilterReducer.ts
@@ -12,7 +12,7 @@ import {
 } from '../api/shieldsAPI'
 import { reloadTab } from '../api/tabsAPI'
 import * as shieldsPanelState from '../../state/shieldsPanelState'
-import { State, Tab } from '../../types/state/shieldsPannelState'
+import { State } from '../../types/state/shieldsPannelState'
 import { Actions } from '../../types/actions/index'
 import * as cosmeticFilterTypes from '../../constants/cosmeticFilterTypes'
 import {
@@ -55,7 +55,11 @@ export default function cosmeticFilterReducer (state: State = {
       }
     case webNavigationTypes.ON_COMMITTED:
       {
-        const tabData: Tab = shieldsPanelState.getActiveTabData(state)
+        const tabData = shieldsPanelState.getActiveTabData(state)
+        if (!tabData) {
+          console.error('Active tab not found')
+          break
+        }
         applySiteFilters(tabData.hostname)
         break
       }
@@ -111,8 +115,9 @@ export default function cosmeticFilterReducer (state: State = {
     case shieldsPanelTypes.SHIELDS_TOGGLED:
       {
         const tabId: number = shieldsPanelState.getActiveTabId(state)
-        const tabData: Tab = shieldsPanelState.getActiveTabData(state)
+        const tabData = shieldsPanelState.getActiveTabData(state)
         if (!tabData) {
+          console.error('Active tab not found')
           break
         }
         setAllowBraveShields(tabData.origin, action.setting)

--- a/app/background/reducers/shieldsPanelReducer.ts
+++ b/app/background/reducers/shieldsPanelReducer.ts
@@ -132,8 +132,9 @@ export default function shieldsPanelReducer (state: State = { tabs: {}, windows:
     case shieldsPanelTypes.SHIELDS_TOGGLED:
       {
         const tabId: number = shieldsPanelState.getActiveTabId(state)
-        const tabData: Tab = shieldsPanelState.getActiveTabData(state)
+        const tabData = shieldsPanelState.getActiveTabData(state)
         if (!tabData) {
+          console.error('Active tab not found')
           break
         }
         setAllowBraveShields(tabData.origin, action.setting)
@@ -152,8 +153,9 @@ export default function shieldsPanelReducer (state: State = { tabs: {}, windows:
       }
     case shieldsPanelTypes.HTTPS_EVERYWHERE_TOGGLED:
       {
-        const tabData: Tab = shieldsPanelState.getActiveTabData(state)
+        const tabData = shieldsPanelState.getActiveTabData(state)
         if (!tabData) {
+          console.error('Active tab not found')
           break
         }
 
@@ -171,7 +173,11 @@ export default function shieldsPanelReducer (state: State = { tabs: {}, windows:
       }
     case shieldsPanelTypes.JAVASCRIPT_TOGGLED:
       {
-        const tabData: Tab = shieldsPanelState.getActiveTabData(state)
+        const tabData = shieldsPanelState.getActiveTabData(state)
+        if (!tabData) {
+          console.error('Active tab not found')
+          break
+        }
         setAllowJavaScript(tabData.origin, toggleShieldsValue(tabData.javascript))
           .then(() => {
             requestShieldPanelData(shieldsPanelState.getActiveTabId(state))
@@ -198,9 +204,10 @@ export default function shieldsPanelReducer (state: State = { tabs: {}, windows:
     case shieldsPanelTypes.BLOCK_ADS_TRACKERS:
       {
         const tabId: number = shieldsPanelState.getActiveTabId(state)
-        const tabData: Tab = shieldsPanelState.getActiveTabData(state)
+        const tabData = shieldsPanelState.getActiveTabData(state)
 
         if (!tabData) {
+          console.error('Active tab not found')
           break
         }
 
@@ -234,7 +241,11 @@ export default function shieldsPanelReducer (state: State = { tabs: {}, windows:
       }
     case shieldsPanelTypes.BLOCK_FINGERPRINTING:
       {
-        const tabData: Tab = shieldsPanelState.getActiveTabData(state)
+        const tabData = shieldsPanelState.getActiveTabData(state)
+        if (!tabData) {
+          console.error('Active tab not found')
+          break
+        }
         setAllowFingerprinting(tabData.origin, action.setting)
           .then(() => {
             requestShieldPanelData(shieldsPanelState.getActiveTabId(state))
@@ -249,7 +260,11 @@ export default function shieldsPanelReducer (state: State = { tabs: {}, windows:
       }
     case shieldsPanelTypes.BLOCK_COOKIES:
       {
-        const tabData: Tab = shieldsPanelState.getActiveTabData(state)
+        const tabData = shieldsPanelState.getActiveTabData(state)
+        if (!tabData) {
+          console.error('Active tab not found')
+          break
+        }
         setAllowCookies(tabData.origin, action.setting)
           .then(() => {
             requestShieldPanelData(shieldsPanelState.getActiveTabId(state))
@@ -264,7 +279,11 @@ export default function shieldsPanelReducer (state: State = { tabs: {}, windows:
       }
     case shieldsPanelTypes.ALLOW_SCRIPT_ORIGINS_ONCE:
       {
-        const tabData: Tab = shieldsPanelState.getActiveTabData(state)
+        const tabData = shieldsPanelState.getActiveTabData(state)
+        if (!tabData) {
+          console.error('Active tab not found')
+          break
+        }
         setAllowScriptOriginsOnce(action.origins, tabData.id)
           .then(() => {
             requestShieldPanelData(shieldsPanelState.getActiveTabId(state))

--- a/app/types/state/shieldsPannelState.ts
+++ b/app/types/state/shieldsPannelState.ts
@@ -50,7 +50,7 @@ export interface GetActiveTabId {
 }
 
 export interface GetActiveTabData {
-  (state: State): Tab
+  (state: State): Tab | undefined
 }
 
 export interface UpdateActiveTab {


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/845
Fix https://github.com/brave/brave-browser/issues/846

[state].GetActiveTabData can return undefined from state yet the type did not reflect this even though some calls, but not all calls, handled it.

cosemtic filter list was being read before it was set in storage.