### PR TITLE
Add vscode settings for linting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+  "editor.formatOnPaste": true,
+  "editor.tabSize": 2,
+  "prettier.semi": false,
+  "javascript.preferences.quoteStyle": "auto",
+  "typescript.preferences.quoteStyle": "auto",
+  "prettier.singleQuote": true,
+  "javascript.format.insertSpaceAfterOpeningAndBeforeClosingNonemptyParenthesis": true
+}


### PR DESCRIPTION
If you use VSCode, this commit fixes pasting/auto-linting from vscode/typescript addon. It will no longer try to use double-quotes, semi-colons, or 4 space tabs (default) and show up with all the TypeScript linting errors.

This is referring to the Slack message from @petemill: 
> Looks like this could all be 1 commit. 2 actually, considering the VScode should be a separate commit