### PR TITLE
defer reset of resource and stats blocked to the onCommitted event

### DIFF
--- a/app/background/reducers/cosmeticFilterReducer.ts
+++ b/app/background/reducers/cosmeticFilterReducer.ts
@@ -45,20 +45,17 @@ export default function cosmeticFilterReducer (state: State = {
   currentWindowId: -1 },
   action: Actions) {
   switch (action.type) {
-    case webNavigationTypes.ON_BEFORE_NAVIGATION:
-      {
-        if (action.isMainFrame) {
-          state = shieldsPanelState.resetBlockingStats(state, action.tabId)
-          state = shieldsPanelState.resetNoScriptInfo(state, action.tabId, new window.URL(action.url).origin)
-        }
-        break
-      }
     case webNavigationTypes.ON_COMMITTED:
       {
         const tabData = shieldsPanelState.getActiveTabData(state)
         if (!tabData) {
           console.error('Active tab not found')
           break
+        }
+        if (action.isMainFrame) {
+          state = shieldsPanelState.resetBlockingStats(state, action.tabId)
+          state = shieldsPanelState.resetBlockingResources(state, action.tabId)
+          state = shieldsPanelState.resetNoScriptInfo(state, action.tabId, new window.URL(action.url).origin)
         }
         applySiteFilters(tabData.hostname)
         break

--- a/app/background/reducers/shieldsPanelReducer.ts
+++ b/app/background/reducers/shieldsPanelReducer.ts
@@ -65,7 +65,7 @@ const updateActiveTab = (state: State, windowId: number, tabId: number): State =
 
 export default function shieldsPanelReducer (state: State = { tabs: {}, windows: {}, currentWindowId: -1 }, action: Actions) {
   switch (action.type) {
-    case webNavigationTypes.ON_BEFORE_NAVIGATION:
+    case webNavigationTypes.ON_COMMITTED:
       {
         if (action.isMainFrame) {
           state = shieldsPanelState.resetBlockingStats(state, action.tabId)

--- a/test/app/background/reducers/cosmeticFilterReducerTest.ts
+++ b/test/app/background/reducers/cosmeticFilterReducerTest.ts
@@ -28,7 +28,7 @@ describe('cosmeticFilterReducer', () => {
     assert.deepEqual(
       shieldsPanelReducer(undefined, actions.blockAdsTrackers('allow')), initialState.cosmeticFilter)
   })
-  describe('ON_BEFORE_NAVIGATION', function () {
+  describe('ON_COMMITTED', function () {
     before(function () {
       this.spy = sinon.spy(shieldsPanelState, 'resetBlockingStats')
       this.resetNoScriptInfoSpy = sinon.spy(shieldsPanelState, 'resetNoScriptInfo')
@@ -46,7 +46,7 @@ describe('cosmeticFilterReducer', () => {
     })
     it('calls resetBlockingStats when isMainFrame is true', function () {
       shieldsPanelReducer(initialState.shieldsPanel, {
-        type: webNavigationTypes.ON_BEFORE_NAVIGATION,
+        type: webNavigationTypes.ON_COMMITTED,
         tabId: this.tabId,
         url: 'https://www.brave.com',
         isMainFrame: true
@@ -56,7 +56,7 @@ describe('cosmeticFilterReducer', () => {
     })
     it('does not call resetBlockingStats when isMainFrame is false', function () {
       shieldsPanelReducer(initialState.shieldsPanel, {
-        type: webNavigationTypes.ON_BEFORE_NAVIGATION,
+        type: webNavigationTypes.ON_COMMITTED,
         tabId: this.tabId,
         url: 'https://www.brave.com',
         isMainFrame: false
@@ -65,7 +65,7 @@ describe('cosmeticFilterReducer', () => {
     })
     it('calls resetNoScriptInfo when isMainFrame is true', function () {
       shieldsPanelReducer(initialState.shieldsPanel, {
-        type: webNavigationTypes.ON_BEFORE_NAVIGATION,
+        type: webNavigationTypes.ON_COMMITTED,
         tabId: this.tabId,
         url: 'https://www.brave.com',
         isMainFrame: true
@@ -76,7 +76,7 @@ describe('cosmeticFilterReducer', () => {
     })
     it('does not call resetNoScriptInfo when isMainFrame is false', function () {
       shieldsPanelReducer(initialState.shieldsPanel, {
-        type: webNavigationTypes.ON_BEFORE_NAVIGATION,
+        type: webNavigationTypes.ON_COMMITTED,
         tabId: this.tabId,
         url: 'https://www.brave.com',
         isMainFrame: false
@@ -85,7 +85,7 @@ describe('cosmeticFilterReducer', () => {
     })
     it('calls resetBlockingResources when isMainFrame is true', function () {
       shieldsPanelReducer(initialState.shieldsPanel, {
-        type: webNavigationTypes.ON_BEFORE_NAVIGATION,
+        type: webNavigationTypes.ON_COMMITTED,
         tabId: this.tabId,
         url: 'https://www.brave.com',
         isMainFrame: true
@@ -95,72 +95,7 @@ describe('cosmeticFilterReducer', () => {
     })
     it('does not call resetBlockingResources when isMainFrame is false', function () {
       shieldsPanelReducer(initialState.shieldsPanel, {
-        type: webNavigationTypes.ON_BEFORE_NAVIGATION,
-        tabId: this.tabId,
-        url: 'https://www.brave.com',
-        isMainFrame: false
-      })
-      assert.equal(this.spy.notCalled, true)
-    })
-  })
-  describe('ON_COMMITTED', function () {
-    before(function () {
-      this.spy = sinon.spy(shieldsPanelState, 'resetBlockingStats')
-      this.resetNoScriptInfoSpy = sinon.spy(shieldsPanelState, 'resetNoScriptInfo')
-      this.resetBlockingResourcesSpy = sinon.spy(shieldsPanelState, 'resetBlockingResources')
-      this.tabId = 1
-    })
-    after(function () {
-      this.spy.restore()
-      this.resetNoScriptInfoSpy.restore()
-      this.resetBlockingResourcesSpy.restore()
-    })
-    afterEach(function () {
-      this.spy.reset()
-      this.resetNoScriptInfoSpy.reset()
-    })
-    it('does not call resetBlockingStats when isMainFrame is false', function () {
-      shieldsPanelReducer(initialState.shieldsPanel, {
-        type: webNavigationTypes.ON_BEFORE_NAVIGATION,
-        tabId: this.tabId,
-        url: 'https://www.brave.com',
-        isMainFrame: false
-      })
-      assert.equal(this.spy.notCalled, true)
-    })
-    it('calls resetNoScriptInfo when isMainFrame is true', function () {
-      shieldsPanelReducer(initialState.shieldsPanel, {
-        type: webNavigationTypes.ON_BEFORE_NAVIGATION,
-        tabId: this.tabId,
-        url: 'https://www.brave.com',
-        isMainFrame: true
-      })
-      assert.equal(this.resetNoScriptInfoSpy.calledOnce, true)
-      assert.equal(this.resetNoScriptInfoSpy.getCall(0).args[1], this.tabId)
-      assert.equal(this.resetNoScriptInfoSpy.getCall(0).args[2], 'https://www.brave.com')
-    })
-    it('does not call resetNoScriptInfo when isMainFrame is false', function () {
-      shieldsPanelReducer(initialState.shieldsPanel, {
-        type: webNavigationTypes.ON_BEFORE_NAVIGATION,
-        tabId: this.tabId,
-        url: 'https://www.brave.com',
-        isMainFrame: false
-      })
-      assert.equal(this.resetNoScriptInfoSpy.notCalled, true)
-    })
-    it('calls resetBlockingResources when isMainFrame is true', function () {
-      shieldsPanelReducer(initialState.shieldsPanel, {
-        type: webNavigationTypes.ON_BEFORE_NAVIGATION,
-        tabId: this.tabId,
-        url: 'https://www.brave.com',
-        isMainFrame: true
-      })
-      assert.equal(this.spy.calledOnce, true)
-      assert.equal(this.spy.getCall(0).args[1], this.tabId)
-    })
-    it('does not call resetBlockingResources when isMainFrame is false', function () {
-      shieldsPanelReducer(initialState.shieldsPanel, {
-        type: webNavigationTypes.ON_BEFORE_NAVIGATION,
+        type: webNavigationTypes.ON_COMMITTED,
         tabId: this.tabId,
         url: 'https://www.brave.com',
         isMainFrame: false

--- a/test/app/background/reducers/shieldsPanelReducerTest.ts
+++ b/test/app/background/reducers/shieldsPanelReducerTest.ts
@@ -28,7 +28,7 @@ describe('braveShieldsPanelReducer', () => {
     , initialState.shieldsPanel)
   })
 
-  describe('ON_BEFORE_NAVIGATION', function () {
+  describe('ON_COMMITTED', function () {
     before(function () {
       this.spy = sinon.spy(shieldsPanelState, 'resetBlockingStats')
       this.resetNoScriptInfoSpy = sinon.spy(shieldsPanelState, 'resetNoScriptInfo')
@@ -46,7 +46,7 @@ describe('braveShieldsPanelReducer', () => {
     })
     it('calls resetBlockingStats when isMainFrame is true', function () {
       shieldsPanelReducer(initialState.shieldsPanel, {
-        type: webNavigationTypes.ON_BEFORE_NAVIGATION,
+        type: webNavigationTypes.ON_COMMITTED,
         tabId: this.tabId,
         url: 'https://www.brave.com',
         isMainFrame: true
@@ -56,7 +56,7 @@ describe('braveShieldsPanelReducer', () => {
     })
     it('does not call resetBlockingStats when isMainFrame is false', function () {
       shieldsPanelReducer(initialState.shieldsPanel, {
-        type: webNavigationTypes.ON_BEFORE_NAVIGATION,
+        type: webNavigationTypes.ON_COMMITTED,
         tabId: this.tabId,
         url: 'https://www.brave.com',
         isMainFrame: false
@@ -65,7 +65,7 @@ describe('braveShieldsPanelReducer', () => {
     })
     it('calls resetNoScriptInfo when isMainFrame is true', function () {
       shieldsPanelReducer(initialState.shieldsPanel, {
-        type: webNavigationTypes.ON_BEFORE_NAVIGATION,
+        type: webNavigationTypes.ON_COMMITTED,
         tabId: this.tabId,
         url: 'https://www.brave.com',
         isMainFrame: true
@@ -76,7 +76,7 @@ describe('braveShieldsPanelReducer', () => {
     })
     it('does not call resetNoScriptInfo when isMainFrame is false', function () {
       shieldsPanelReducer(initialState.shieldsPanel, {
-        type: webNavigationTypes.ON_BEFORE_NAVIGATION,
+        type: webNavigationTypes.ON_COMMITTED,
         tabId: this.tabId,
         url: 'https://www.brave.com',
         isMainFrame: false
@@ -85,7 +85,7 @@ describe('braveShieldsPanelReducer', () => {
     })
     it('calls resetBlockingResources when isMainFrame is true', function () {
       shieldsPanelReducer(initialState.shieldsPanel, {
-        type: webNavigationTypes.ON_BEFORE_NAVIGATION,
+        type: webNavigationTypes.ON_COMMITTED,
         tabId: this.tabId,
         url: 'https://www.brave.com',
         isMainFrame: true
@@ -95,7 +95,7 @@ describe('braveShieldsPanelReducer', () => {
     })
     it('does not call resetBlockingResources when isMainFrame is false', function () {
       shieldsPanelReducer(initialState.shieldsPanel, {
-        type: webNavigationTypes.ON_BEFORE_NAVIGATION,
+        type: webNavigationTypes.ON_COMMITTED,
         tabId: this.tabId,
         url: 'https://www.brave.com',
         isMainFrame: false


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/429

`onBeforeNavigate` sometimes fire too soon and stats are reset when some resources are still being blocked -- leading next page to inherit its blocked resources.

Test Plan:

described in https://github.com/brave/brave-browser/issues/429#issue-335822438

Tests are updated and CI should also pass.
