### PR TITLE
Use braveShields's contentSetting method for shield configuration

### DIFF
--- a/app/background.ts
+++ b/app/background.ts
@@ -30,7 +30,7 @@ promisifyAll(chrome.storage, [
   'local'
 ])
 
-promisifyAll(chrome.contentSettings, [
+promisifyAll(chrome.braveShields, [
   'javascript',
   'plugins'
 ])

--- a/app/background/api/shieldsAPI.ts
+++ b/app/background/api/shieldsAPI.ts
@@ -22,15 +22,15 @@ export const getShieldSettingsForTabData = (tabData?: chrome.tabs.Tab) => {
   const hostname = url.hostname
 
   return Promise.all([
-    chrome.contentSettings.plugins.getAsync({ primaryUrl: origin, resourceIdentifier: { id: resourceIdentifiers.RESOURCE_IDENTIFIER_BRAVE_SHIELDS } }),
-    chrome.contentSettings.plugins.getAsync({ primaryUrl: origin, resourceIdentifier: { id: resourceIdentifiers.RESOURCE_IDENTIFIER_ADS } }),
-    chrome.contentSettings.plugins.getAsync({ primaryUrl: origin, resourceIdentifier: { id: resourceIdentifiers.RESOURCE_IDENTIFIER_TRACKERS } }),
-    chrome.contentSettings.plugins.getAsync({ primaryUrl: origin, resourceIdentifier: { id: resourceIdentifiers.RESOURCE_IDENTIFIER_HTTP_UPGRADABLE_RESOURCES } }),
-    chrome.contentSettings.javascript.getAsync({ primaryUrl: origin }),
-    chrome.contentSettings.plugins.getAsync({ primaryUrl: origin, resourceIdentifier: { id: resourceIdentifiers.RESOURCE_IDENTIFIER_FINGERPRINTING } }),
-    chrome.contentSettings.plugins.getAsync({ primaryUrl: origin, secondaryUrl: 'https://firstParty/*', resourceIdentifier: { id: resourceIdentifiers.RESOURCE_IDENTIFIER_FINGERPRINTING } }),
-    chrome.contentSettings.plugins.getAsync({ primaryUrl: origin, resourceIdentifier: { id: resourceIdentifiers.RESOURCE_IDENTIFIER_COOKIES } }),
-    chrome.contentSettings.plugins.getAsync({ primaryUrl: origin, secondaryUrl: 'https://firstParty/', resourceIdentifier: { id: resourceIdentifiers.RESOURCE_IDENTIFIER_COOKIES } })
+    chrome.braveShields.plugins.getAsync({ primaryUrl: origin, resourceIdentifier: { id: resourceIdentifiers.RESOURCE_IDENTIFIER_BRAVE_SHIELDS } }),
+    chrome.braveShields.plugins.getAsync({ primaryUrl: origin, resourceIdentifier: { id: resourceIdentifiers.RESOURCE_IDENTIFIER_ADS } }),
+    chrome.braveShields.plugins.getAsync({ primaryUrl: origin, resourceIdentifier: { id: resourceIdentifiers.RESOURCE_IDENTIFIER_TRACKERS } }),
+    chrome.braveShields.plugins.getAsync({ primaryUrl: origin, resourceIdentifier: { id: resourceIdentifiers.RESOURCE_IDENTIFIER_HTTP_UPGRADABLE_RESOURCES } }),
+    chrome.braveShields.javascript.getAsync({ primaryUrl: origin }),
+    chrome.braveShields.plugins.getAsync({ primaryUrl: origin, resourceIdentifier: { id: resourceIdentifiers.RESOURCE_IDENTIFIER_FINGERPRINTING } }),
+    chrome.braveShields.plugins.getAsync({ primaryUrl: origin, secondaryUrl: 'https://firstParty/*', resourceIdentifier: { id: resourceIdentifiers.RESOURCE_IDENTIFIER_FINGERPRINTING } }),
+    chrome.braveShields.plugins.getAsync({ primaryUrl: origin, resourceIdentifier: { id: resourceIdentifiers.RESOURCE_IDENTIFIER_COOKIES } }),
+    chrome.braveShields.plugins.getAsync({ primaryUrl: origin, secondaryUrl: 'https://firstParty/', resourceIdentifier: { id: resourceIdentifiers.RESOURCE_IDENTIFIER_COOKIES } })
   ]).then((details) => {
     const fingerprinting = details[5].setting !== details[6].setting ? 'block_third_party' : details[5].setting
     const cookies = details[7].setting !== details[8].setting ? 'block_third_party' : details[7].setting
@@ -90,7 +90,7 @@ export const requestShieldPanelData = (tabId: number) =>
  * @return a promise which resolves when the setting is set
  */
 export const setAllowBraveShields = (origin: string, setting: string) =>
-  chrome.contentSettings.plugins.setAsync({
+  chrome.braveShields.plugins.setAsync({
     primaryPattern: origin.replace(/^(http|https):\/\//, '*://') + '/*',
     resourceIdentifier: { id: resourceIdentifiers.RESOURCE_IDENTIFIER_BRAVE_SHIELDS },
     setting
@@ -104,7 +104,7 @@ export const setAllowBraveShields = (origin: string, setting: string) =>
  * @return a promise which resolves when the setting is set
  */
 export const setAllowAds = (origin: string, setting: string) =>
-  chrome.contentSettings.plugins.setAsync({
+  chrome.braveShields.plugins.setAsync({
     primaryPattern: origin + '/*',
     resourceIdentifier: { id: resourceIdentifiers.RESOURCE_IDENTIFIER_ADS },
     setting
@@ -118,7 +118,7 @@ export const setAllowAds = (origin: string, setting: string) =>
  * @return a promise which resolves with the setting is set
  */
 export const setAllowTrackers = (origin: string, setting: string) =>
-  chrome.contentSettings.plugins.setAsync({
+  chrome.braveShields.plugins.setAsync({
     primaryPattern: origin + '/*',
     resourceIdentifier: { id: resourceIdentifiers.RESOURCE_IDENTIFIER_TRACKERS },
     setting
@@ -132,7 +132,7 @@ export const setAllowTrackers = (origin: string, setting: string) =>
  */
 export const setAllowHTTPUpgradableResources = (origin: string, setting: BlockOptions) => {
   const primaryPattern = origin.replace(/^(http|https):\/\//, '*://') + '/*'
-  return chrome.contentSettings.plugins.setAsync({
+  return chrome.braveShields.plugins.setAsync({
     primaryPattern,
     resourceIdentifier: { id: resourceIdentifiers.RESOURCE_IDENTIFIER_HTTP_UPGRADABLE_RESOURCES },
     setting
@@ -146,7 +146,7 @@ export const setAllowHTTPUpgradableResources = (origin: string, setting: BlockOp
  * @return a promise which resolves when the setting is set
  */
 export const setAllowJavaScript = (origin: string, setting: string) =>
-  chrome.contentSettings.javascript.setAsync({
+  chrome.braveShields.javascript.setAsync({
     primaryPattern: origin + '/*',
     setting
   })
@@ -161,13 +161,13 @@ export const setAllowFingerprinting = (origin: string, setting: string) => {
   const originSetting = setting === 'allow' ? 'allow' : 'block'
   const firstPartySetting = setting === 'block' ? 'block' : 'allow'
 
-  const p1 = chrome.contentSettings.plugins.setAsync({
+  const p1 = chrome.braveShields.plugins.setAsync({
     primaryPattern: origin + '/*',
     resourceIdentifier: { id: resourceIdentifiers.RESOURCE_IDENTIFIER_FINGERPRINTING },
     setting: originSetting
   })
 
-  const p2 = chrome.contentSettings.plugins.setAsync({
+  const p2 = chrome.braveShields.plugins.setAsync({
     primaryPattern: origin + '/*',
     secondaryPattern: 'https://firstParty/*',
     resourceIdentifier: { id: resourceIdentifiers.RESOURCE_IDENTIFIER_FINGERPRINTING },
@@ -186,19 +186,19 @@ export const setAllowCookies = (origin: string, setting: string) => {
   const originSetting = setting === 'allow' ? 'allow' : 'block'
   const firstPartySetting = setting === 'block' ? 'block' : 'allow'
 
-  const p1 = chrome.contentSettings.plugins.setAsync({
+  const p1 = chrome.braveShields.plugins.setAsync({
     primaryPattern: origin + '/*',
     resourceIdentifier: { id: resourceIdentifiers.RESOURCE_IDENTIFIER_REFERRERS },
     setting: originSetting
   })
 
-  const p2 = chrome.contentSettings.plugins.setAsync({
+  const p2 = chrome.braveShields.plugins.setAsync({
     primaryPattern: origin + '/*',
     resourceIdentifier: { id: resourceIdentifiers.RESOURCE_IDENTIFIER_COOKIES },
     setting: originSetting
   })
 
-  const p3 = chrome.contentSettings.plugins.setAsync({
+  const p3 = chrome.braveShields.plugins.setAsync({
     primaryPattern: origin + '/*',
     secondaryPattern: 'https://firstParty/*',
     resourceIdentifier: { id: resourceIdentifiers.RESOURCE_IDENTIFIER_COOKIES },

--- a/app/types/global/chrome.d.ts
+++ b/app/types/global/chrome.d.ts
@@ -26,13 +26,6 @@ declare namespace chrome.windows {
   const getAllAsync: any
 }
 
-declare namespace chrome.contentSettings {
-  interface ContentSetting {
-    setAsync: any
-    getAsync: any
-  }
-}
-
 declare namespace chrome.braveShields {
   const onBlocked: {
     addListener: (callback: (detail: BlockDetails) => void) => void
@@ -40,4 +33,6 @@ declare namespace chrome.braveShields {
   }
 
   const allowScriptsOnce: any
+  const javascript: any
+  const plugins: any
 }

--- a/test/app/background/api/shieldsAPITest.ts
+++ b/test/app/background/api/shieldsAPITest.ts
@@ -187,13 +187,13 @@ describe('Shields API', () => {
 
   describe('setAllowAds', function () {
     before(function () {
-      this.spy = sinon.spy(chrome.contentSettings.plugins, 'setAsync')
+      this.spy = sinon.spy(chrome.braveShields.plugins, 'setAsync')
       this.p = shieldsAPI.setAllowAds('https://www.brave.com', 'block')
     })
     after(function () {
       this.spy.restore()
     })
-    it('calls chrome.contentSettings.plugins with the correct args', function () {
+    it('calls chrome.braveShields.plugins with the correct args', function () {
       const arg0 = this.spy.getCall(0).args[0]
       assert.deepEqual(arg0, {
         primaryPattern: 'https://www.brave.com/*',
@@ -201,7 +201,7 @@ describe('Shields API', () => {
         setting: 'block'
       })
     })
-    it('passes only 1 arg to chrome.contentSettings.plugins', function () {
+    it('passes only 1 arg to chrome.braveShields.plugins', function () {
       assert.equal(this.spy.getCall(0).args.length, 1)
     })
     it('resolves the returned promise', function (cb) {
@@ -215,13 +215,13 @@ describe('Shields API', () => {
 
   describe('setAllowTrackers', function () {
     before(function () {
-      this.spy = sinon.spy(chrome.contentSettings.plugins, 'setAsync')
+      this.spy = sinon.spy(chrome.braveShields.plugins, 'setAsync')
       this.p = shieldsAPI.setAllowTrackers('https://www.brave.com', 'block')
     })
     after(function () {
       this.spy.restore()
     })
-    it('calls chrome.contentSettings.plugins with the correct args', function () {
+    it('calls chrome.braveShields.plugins with the correct args', function () {
       const arg0 = this.spy.getCall(0).args[0]
       assert.deepEqual(arg0, {
         primaryPattern: 'https://www.brave.com/*',
@@ -229,7 +229,7 @@ describe('Shields API', () => {
         setting: 'block'
       })
     })
-    it('passes only 1 arg to chrome.contentSettings.plugins', function () {
+    it('passes only 1 arg to chrome.braveShields.plugins', function () {
       assert.equal(this.spy.getCall(0).args.length, 1)
     })
     it('resolves the returned promise', function (cb) {
@@ -243,13 +243,13 @@ describe('Shields API', () => {
 
   describe('setAllowHTTPUpgradableResource', function () {
     before(function () {
-      this.spy = sinon.spy(chrome.contentSettings.plugins, 'setAsync')
+      this.spy = sinon.spy(chrome.braveShields.plugins, 'setAsync')
       this.p = shieldsAPI.setAllowHTTPUpgradableResources('https://www.brave.com', 'block')
     })
     after(function () {
       this.spy.restore()
     })
-    it('calls chrome.contentSettings.plugins with the correct args', function () {
+    it('calls chrome.braveShields.plugins with the correct args', function () {
       const arg0 = this.spy.getCall(0).args[0]
       assert.deepEqual(arg0, {
         primaryPattern: '*://www.brave.com/*',
@@ -257,7 +257,7 @@ describe('Shields API', () => {
         setting: 'block'
       })
     })
-    it('passes only 1 arg to chrome.contentSettings.plugins', function () {
+    it('passes only 1 arg to chrome.braveShields.plugins', function () {
       assert.equal(this.spy.getCall(0).args.length, 1)
     })
     it('resolves the returned promise', function (cb) {
@@ -271,7 +271,7 @@ describe('Shields API', () => {
 
   describe('setAllowJavaScript', function () {
     before(function () {
-      this.spy = sinon.spy(chrome.contentSettings.javascript, 'setAsync')
+      this.spy = sinon.spy(chrome.braveShields.javascript, 'setAsync')
       this.p = shieldsAPI.setAllowJavaScript('https://www.brave.com', 'block')
     })
 
@@ -279,7 +279,7 @@ describe('Shields API', () => {
       this.spy.restore()
     })
 
-    it('calls chrome.contentSettings.plugins with the correct args', function () {
+    it('calls chrome.braveShields.plugins with the correct args', function () {
       const arg0 = this.spy.getCall(0).args[0]
       assert.deepEqual(arg0, {
         primaryPattern: 'https://www.brave.com/*',
@@ -287,7 +287,7 @@ describe('Shields API', () => {
       })
     })
 
-    it('passes only 1 arg to chrome.contentSettings.plugins', function () {
+    it('passes only 1 arg to chrome.braveShields.plugins', function () {
       assert.equal(this.spy.getCall(0).args.length, 1)
     })
 
@@ -302,13 +302,13 @@ describe('Shields API', () => {
 
   describe('setAllowFingerprinting', function () {
     before(function () {
-      this.spy = sinon.spy(chrome.contentSettings.plugins, 'setAsync')
+      this.spy = sinon.spy(chrome.braveShields.plugins, 'setAsync')
       this.p = shieldsAPI.setAllowFingerprinting('https://www.brave.com', 'block')
     })
     after(function () {
       this.spy.restore()
     })
-    it('calls chrome.contentSettings.plugins with the correct args', function () {
+    it('calls chrome.braveShields.plugins with the correct args', function () {
       const arg0 = this.spy.getCall(0).args[0]
       assert.deepEqual(arg0, {
         primaryPattern: 'https://www.brave.com/*',
@@ -323,7 +323,7 @@ describe('Shields API', () => {
         setting: 'block'
       })
     })
-    it('passes only 1 arg to chrome.contentSettings.plugins', function () {
+    it('passes only 1 arg to chrome.braveShields.plugins', function () {
       assert.equal(this.spy.getCall(0).args.length, 1)
       assert.equal(this.spy.getCall(1).args.length, 1)
     })
@@ -340,13 +340,13 @@ describe('Shields API', () => {
 
   describe('setAllowCookies', function () {
     before(function () {
-      this.spy = sinon.spy(chrome.contentSettings.plugins, 'setAsync')
+      this.spy = sinon.spy(chrome.braveShields.plugins, 'setAsync')
       this.p = shieldsAPI.setAllowCookies('https://www.brave.com', 'block')
     })
     after(function () {
       this.spy.restore()
     })
-    it('calls chrome.contentSettings.plugins with the correct args', function () {
+    it('calls chrome.braveShields.plugins with the correct args', function () {
       const arg0 = this.spy.getCall(0).args[0]
       assert.deepEqual(arg0, {
         primaryPattern: 'https://www.brave.com/*',
@@ -367,7 +367,7 @@ describe('Shields API', () => {
         setting: 'block'
       })
     })
-    it('passes only 1 arg to chrome.contentSettings.plugins', function () {
+    it('passes only 1 arg to chrome.braveShields.plugins', function () {
       assert.equal(this.spy.getCall(0).args.length, 1)
       assert.equal(this.spy.getCall(1).args.length, 1)
     })

--- a/test/testData.ts
+++ b/test/testData.ts
@@ -110,9 +110,7 @@ export const getMockChrome = () => {
       onBlocked: new ChromeEvent(),
       allowScriptsOnce: function (origins: Array<string>, tabId: number, cb: () => void) {
         setImmediate(cb)
-      }
-    },
-    contentSettings: {
+      },
       plugins: {
         setAsync: function () {
           return Promise.resolve()


### PR DESCRIPTION
Use braveShields's contentSetting method instead of chrome.contentSetting.
This will enable user able to edit shields setting.
So far, user can't edit shields setting because chrome doesn't allow editing configuration set by extension.
Our new methods stores configuration to user preference store instead of extension store.

This PR should be merged after reviewing https://github.com/brave/brave-core/pull/439.

Issue https://github.com/brave/brave-browser/issues/232