### PR TITLE
Only keep user-allowed origins in the noScriptInfo when a navigation …

### DIFF
--- a/app/state/shieldsPanelState.ts
+++ b/app/state/shieldsPanelState.ts
@@ -108,7 +108,13 @@ export const resetNoScriptInfo: shieldState.ResetNoScriptInfo = (state, tabId, n
   if (newOrigin !== tabs[tabId].origin) { // navigate away
     tabs[tabId].noScriptInfo = {}
   }
-  Object.keys(tabs[tabId].noScriptInfo).map(key => tabs[tabId].noScriptInfo[key].actuallyBlocked = false)
+  Object.keys(tabs[tabId].noScriptInfo).map(key => {
+    tabs[tabId].noScriptInfo[key].actuallyBlocked = false
+    // only keep entries which users want to allow
+    if (tabs[tabId].noScriptInfo[key].willBlock) {
+      delete tabs[tabId].noScriptInfo[key]
+    }
+  })
   return { ...state, tabs }
 }
 

--- a/test/app/state/shieldsPanelStateTest.ts
+++ b/test/app/state/shieldsPanelStateTest.ts
@@ -729,7 +729,7 @@ describe('shieldsPanelState test', () => {
           url: 'https://brave.com',
           noScriptInfo: {
             'https://a.com': { actuallyBlocked: true, willBlock: true },
-            'https://b.com': { actuallyBlocked: false, willBlock: false }
+            'https://b.com': { actuallyBlocked: true, willBlock: false }
           },
           adsBlockedResources: [],
           trackersBlockedResources: [],
@@ -796,7 +796,6 @@ describe('shieldsPanelState test', () => {
               fingerprintingBlocked: 0,
               url: 'https://brave.com',
               noScriptInfo: {
-                'https://a.com': { actuallyBlocked: false, willBlock: true },
                 'https://b.com': { actuallyBlocked: false, willBlock: false }
               },
               adsBlockedResources: [],


### PR DESCRIPTION
…is commited

This is a part of fixing https://github.com/brave/brave-browser/issues/230, which improve UI for a bit to be less confused.