### PR TITLE
Add scope to methods which modify content settings

### DIFF
--- a/app/background/api/shieldsAPI.ts
+++ b/app/background/api/shieldsAPI.ts
@@ -63,6 +63,9 @@ export const getShieldSettingsForTabData = (tabData?: chrome.tabs.Tab) => {
   })
 }
 
+const getScope = () =>
+  chrome.extension.inIncognitoContext ? 'incognito_session_only' : 'regular'
+
 /**
  * Obtains specified tab data
  * @return a promise with the active tab data
@@ -93,7 +96,8 @@ export const setAllowBraveShields = (origin: string, setting: string) =>
   chrome.braveShields.plugins.setAsync({
     primaryPattern: origin.replace(/^(http|https):\/\//, '*://') + '/*',
     resourceIdentifier: { id: resourceIdentifiers.RESOURCE_IDENTIFIER_BRAVE_SHIELDS },
-    setting
+    setting,
+    scope: getScope()
   })
 
 /**
@@ -107,7 +111,8 @@ export const setAllowAds = (origin: string, setting: string) =>
   chrome.braveShields.plugins.setAsync({
     primaryPattern: origin + '/*',
     resourceIdentifier: { id: resourceIdentifiers.RESOURCE_IDENTIFIER_ADS },
-    setting
+    setting,
+    scope: getScope()
   })
 
 /**
@@ -121,7 +126,8 @@ export const setAllowTrackers = (origin: string, setting: string) =>
   chrome.braveShields.plugins.setAsync({
     primaryPattern: origin + '/*',
     resourceIdentifier: { id: resourceIdentifiers.RESOURCE_IDENTIFIER_TRACKERS },
-    setting
+    setting,
+    scope: getScope()
   })
 
 /**
@@ -135,7 +141,8 @@ export const setAllowHTTPUpgradableResources = (origin: string, setting: BlockOp
   return chrome.braveShields.plugins.setAsync({
     primaryPattern,
     resourceIdentifier: { id: resourceIdentifiers.RESOURCE_IDENTIFIER_HTTP_UPGRADABLE_RESOURCES },
-    setting
+    setting,
+    scope: getScope()
   })
 }
 
@@ -148,7 +155,8 @@ export const setAllowHTTPUpgradableResources = (origin: string, setting: BlockOp
 export const setAllowJavaScript = (origin: string, setting: string) =>
   chrome.braveShields.javascript.setAsync({
     primaryPattern: origin + '/*',
-    setting
+    setting,
+    scope: getScope()
   })
 
 /**
@@ -164,14 +172,16 @@ export const setAllowFingerprinting = (origin: string, setting: string) => {
   const p1 = chrome.braveShields.plugins.setAsync({
     primaryPattern: origin + '/*',
     resourceIdentifier: { id: resourceIdentifiers.RESOURCE_IDENTIFIER_FINGERPRINTING },
-    setting: originSetting
+    setting: originSetting,
+    scope: getScope()
   })
 
   const p2 = chrome.braveShields.plugins.setAsync({
     primaryPattern: origin + '/*',
     secondaryPattern: 'https://firstParty/*',
     resourceIdentifier: { id: resourceIdentifiers.RESOURCE_IDENTIFIER_FINGERPRINTING },
-    setting: firstPartySetting
+    setting: firstPartySetting,
+    scope: getScope()
   })
 
   return Promise.all([p1, p2])
@@ -189,20 +199,23 @@ export const setAllowCookies = (origin: string, setting: string) => {
   const p1 = chrome.braveShields.plugins.setAsync({
     primaryPattern: origin + '/*',
     resourceIdentifier: { id: resourceIdentifiers.RESOURCE_IDENTIFIER_REFERRERS },
-    setting: originSetting
+    setting: originSetting,
+    scope: getScope()
   })
 
   const p2 = chrome.braveShields.plugins.setAsync({
     primaryPattern: origin + '/*',
     resourceIdentifier: { id: resourceIdentifiers.RESOURCE_IDENTIFIER_COOKIES },
-    setting: originSetting
+    setting: originSetting,
+    scope: getScope()
   })
 
   const p3 = chrome.braveShields.plugins.setAsync({
     primaryPattern: origin + '/*',
     secondaryPattern: 'https://firstParty/*',
     resourceIdentifier: { id: resourceIdentifiers.RESOURCE_IDENTIFIER_COOKIES },
-    setting: firstPartySetting
+    setting: firstPartySetting,
+    scope: getScope()
   })
 
   return Promise.all([p1, p2, p3])


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/1198

_Known issue: content settings from public windows are NOT inherited into private windows. ex: if you visit https://www.dailymail.co.uk and disable shields in a tab and then open a new private window, that shields off setting is not propagated to the private window. This is a separate bug that needs to be tracked which was not caused by this PR._

_If this PR is approved/merged, I will create an issue to track that problem_

## Reviewer setup steps
1. Get latest `brave-browser` (master branch)
2. Update `package.json` to have branch `content-settings-add-scope` for `brave-core`
3. Run `npm run init` or `npm run sync -- --all`
4. Build with `npm run build`
5. Launch with `npm start`

## Test plan
### Part 1: Test that shields down/up works fine
1. Have a fresh profile and launch Brave
2. Open a new private window
3. Navigate to https://www.dailymail.co.uk
4. Click the shields icon in the URL bar
5. Turn shields off and ensure page reloads and that ads are shown (icon should be gray)
6. Open a new tab in this private window and visit the same URL (https://www.dailymail.co.uk)
7. Verify shields are already be down, because content settings have been applied for this session.
8. Close this second tab and go back to original tab (from step 3)
9. Turn shields back on and ensure page reloads and that ads are NOT shown (icon should have block count)

### Part 2: test other content_settings
10. Repeat steps 3 - 9, but for the other specific content_settings (`Ad Control`, `Cookie Control`, `Fingerprinting Protection`, `HTTPS Everywhere`, `Block Scripts`)

### Part 3: verify that settings are NOT persisted
11. Make a specific settings change, like turning off shields for https://www.dailymail.co.uk
12. Close the private window and open a new private window
13. Navigate again to https://www.dailymail.co.uk
14. Verify that the change you made in step 11 didn't persist
15. Exit browser
16. Re-launch Brave and open a new private window
17. Navigate again to https://www.dailymail.co.uk
18. Verify that the change you made in step 11 didn't persist