### PR TITLE
Only show shield icon as disabled when the shield is explicitly blocked.

### DIFF
--- a/app/background/reducers/shieldsPanelReducer.ts
+++ b/app/background/reducers/shieldsPanelReducer.ts
@@ -39,7 +39,7 @@ const updateShieldsIconImage = (state: State) => {
   const tab: Tab = state.tabs[tabId]
   if (tab) {
     const url: string = tab.url
-    const isShieldsActive: boolean = state.tabs[tabId].braveShields === 'allow'
+    const isShieldsActive: boolean = state.tabs[tabId].braveShields !== 'block'
     setIcon(url, tabId, isShieldsActive)
   }
 }


### PR DESCRIPTION
After https://github.com/brave/brave-core/pull/622, we don't have default allow rules for shields.
Change the logic for isShieldsActive to adapt this change, the new logic is now consistent with how we check the shield toggle status.
