### PR TITLE
add deeplink to the shields section

### DIFF
--- a/app/components/braveShields/footer.tsx
+++ b/app/components/braveShields/footer.tsx
@@ -14,7 +14,7 @@ import { getMessage } from '../../background/api/localeAPI'
 export default class ShieldsFooter extends React.PureComponent<{}, {}> {
   openSettings = (event: React.MouseEvent<HTMLAnchorElement>) => {
     event.preventDefault()
-    tabsAPI.createTab({ url: 'chrome://settings' })
+    tabsAPI.createTab({ url: 'chrome://settings/shields' })
       .catch((err) => console.log(err))
   }
   render () {


### PR DESCRIPTION
needs https://github.com/brave/brave-core/pull/785

fix https://github.com/brave/brave-browser/issues/1959

Test Plan: link to global shields settings should go to brave://settings/shields