### PR TITLE
remove debugging console which shows up on every right-click

### DIFF
--- a/app/content.ts
+++ b/app/content.ts
@@ -7,7 +7,7 @@ function getCurrentURL () {
 document.addEventListener('contextmenu', (event) => {
   let selector = unique(event.target) // this has to be done here, events can't be passed through the messaging API
   let baseURI = getCurrentURL()
-  console.log(selector, baseURI)
+
   chrome.runtime.sendMessage({
     selector: selector,
     baseURI: baseURI


### PR DESCRIPTION
hi guys, noticed that right clicking will always trigger a `console.log` when playing around with the browser.. pretty sure its unintentional leftover from a debugging session.. so i removed it.. let me know if there's anything I should change :+1: 