### PR TITLE
Remove console log in cosmetic filter

### DIFF
--- a/app/content.ts
+++ b/app/content.ts
@@ -7,7 +7,6 @@ function getCurrentURL () {
 document.addEventListener('contextmenu', (event) => {
   let selector = unique(event.target) // this has to be done here, events can't be passed through the messaging API
   let baseURI = getCurrentURL()
-  console.log(selector, baseURI)
   chrome.runtime.sendMessage({
     selector: selector,
     baseURI: baseURI


### PR DESCRIPTION
I was looking at issues with the good first bug tag and I saw https://github.com/brave/brave-browser/issues/2036.

I'm not sure if I understand this correctly. I'm interpreting the issue as simply wanting the line logging to console removed. I think this should fix that.

I haven't tested because I'm still having some trouble running local modifications to the extension repo which I have outlined here https://github.com/brave/brave-browser/issues/2404