### PR TITLE
Fix shields isn't toggled when url has port number

### DIFF
--- a/app/helpers/urlUtils.ts
+++ b/app/helpers/urlUtils.ts
@@ -2,9 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import * as urlParser from 'url'
+
 export const isHttpOrHttps = (url?: string) => {
   if (!url) {
     return false
   }
   return /^https?:/i.test(url)
+}
+
+export const hasPortNumber = (url: string) => {
+  return typeof urlParser.parse(url).port === 'string'
 }

--- a/test/app/helpers/urlUtilsTest.ts
+++ b/test/app/helpers/urlUtilsTest.ts
@@ -4,7 +4,7 @@
 
 import 'mocha'
 import * as assert from 'assert'
-import { isHttpOrHttps } from '../../../app/helpers/urlUtils'
+import { isHttpOrHttps, hasPortNumber } from '../../../app/helpers/urlUtils'
 
 describe('urlUtils test', function () {
   describe('isHttpOrHttps', function () {
@@ -39,6 +39,17 @@ describe('urlUtils test', function () {
     it('matches uppercase https', function () {
       const url = 'HTTP://SCREAMING-UNSAFE-WEBSITE.COM'
       assert.equal(isHttpOrHttps(url), true)
+    })
+  })
+
+  describe('hasPortNumber', function () {
+    it('not a port number if # is located in front of :XXXX', function () {
+      const url = 'http://brianbondy.com#:8080'
+      assert.equal(hasPortNumber(url), false)
+    })
+    it('port number if # is not existed in front of :XXXX', function () {
+      const url = 'http://brianbondy.com:8080'
+      assert.equal(hasPortNumber(url), true)
     })
   })
 })


### PR DESCRIPTION
When url includes port w/o scheme, chromium parses it as an invalid
port number. Because of this, contents setting is failed.
To fix this, scheme is preserved when url has port number.

Fix https://github.com/brave/brave-browser/issues/1896