### PR TITLE
Update sinon dependency to 7.2.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,22 +4,33 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@sinonjs/formatio": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
-      "integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
+    "@sinonjs/commons": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.3.0.tgz",
+      "integrity": "sha512-j4ZwhaHmwsCb4DlDOIWnI5YyKDNMoNThsmwEpfHx6a1EpsGZ9qYLxP++LMlmBRjtGptGHFsGItJ768snllFWpA==",
       "dev": true,
       "requires": {
-        "samsam": "1.3.0"
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/formatio": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.1.0.tgz",
+      "integrity": "sha512-ZAR2bPHOl4Xg6eklUGpsdiIJ4+J1SNag1DHHrG/73Uz/nVwXqjgUtRPLoS+aVyieN9cSbc0E4LsU984tWcDyNg==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/samsam": "^2 || ^3"
       }
     },
     "@sinonjs/samsam": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-2.1.0.tgz",
-      "integrity": "sha512-5x2kFgJYupaF1ns/RmharQ90lQkd2ELS8A9X0ymkAAdemYHGtI2KiUHG8nX2WU0T1qgnOU5YMqnBM2V7NUanNw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.1.0.tgz",
+      "integrity": "sha512-IXio+GWY+Q8XUjHUOgK7wx8fpvr7IFffgyXb1bnJFfX3001KmHt35Zq4tp7MXZyjJPCLPuadesDYNk41LYtVjw==",
       "dev": true,
       "requires": {
-        "array-from": "^2.1.1"
+        "@sinonjs/commons": "^1.0.2",
+        "array-from": "^2.1.1",
+        "lodash.get": "^4.4.2"
       }
     },
     "@types/assert": {
@@ -2818,7 +2829,7 @@
     },
     "core-js": {
       "version": "1.2.7",
-      "resolved": "http://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
       "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
     },
     "core-util-is": {
@@ -4389,7 +4400,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4410,12 +4422,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4430,17 +4444,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4557,7 +4574,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4569,6 +4587,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4583,6 +4602,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4590,12 +4610,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -4614,6 +4636,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4694,7 +4717,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4706,6 +4730,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4791,7 +4816,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4827,6 +4853,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4846,6 +4873,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4889,12 +4917,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -5999,9 +6029,9 @@
       }
     },
     "just-extend": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-3.0.0.tgz",
-      "integrity": "sha512-Fu3T6pKBuxjWT/p4DkqGHFRsysc8OauWr4ZRTY9dIx07Y9O0RkoR5jcv28aeD1vuAwhm3nLkDurwLXoALp4DpQ==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.0.2.tgz",
+      "integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==",
       "dev": true
     },
     "kew": {
@@ -6202,9 +6232,9 @@
       }
     },
     "lolex": {
-      "version": "2.7.5",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.5.tgz",
-      "integrity": "sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-3.0.0.tgz",
+      "integrity": "sha512-hcnW80h3j2lbUfFdMArd5UPA/vxZJ+G8vobd+wg3nVEQA0EigStbYcrG030FJxL6xiDDPEkoMatV9xIh5OecQQ==",
       "dev": true
     },
     "longest": {
@@ -6639,26 +6669,23 @@
       "dev": true
     },
     "nise": {
-      "version": "1.4.6",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-1.4.6.tgz",
-      "integrity": "sha512-1GedetLKzmqmgwabuMSqPsT7oumdR77SBpDfNNJhADRIeA3LN/2RVqR4fFqwvzhAqcTef6PPCzQwITE/YQ8S8A==",
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.4.8.tgz",
+      "integrity": "sha512-kGASVhuL4tlAV0tvA34yJYZIVihrUt/5bDwpp4tTluigxUr2bBlJeDXmivb6NuEdFkqvdv/Ybb9dm16PSKUhtw==",
       "dev": true,
       "requires": {
-        "@sinonjs/formatio": "3.0.0",
-        "just-extend": "^3.0.0",
+        "@sinonjs/formatio": "^3.1.0",
+        "just-extend": "^4.0.2",
         "lolex": "^2.3.2",
         "path-to-regexp": "^1.7.0",
         "text-encoding": "^0.6.4"
       },
       "dependencies": {
-        "@sinonjs/formatio": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.0.0.tgz",
-          "integrity": "sha512-vdjoYLDptCgvtJs57ULshak3iJe4NW3sJ3g36xVDGff5AE8P30S6A093EIEPjdi2noGhfuNOEkbxt3J3awFW1w==",
-          "dev": true,
-          "requires": {
-            "@sinonjs/samsam": "2.1.0"
-          }
+        "lolex": {
+          "version": "2.7.5",
+          "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.5.tgz",
+          "integrity": "sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q==",
+          "dev": true
         }
       }
     },
@@ -8728,12 +8755,6 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
-    "samsam": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
-      "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
-      "dev": true
-    },
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
@@ -8902,18 +8923,18 @@
       "dev": true
     },
     "sinon": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.5.0.tgz",
-      "integrity": "sha512-trdx+mB0VBBgoYucy6a9L7/jfQOmvGeaKZT4OOJ+lPAtI8623xyGr8wLiE4eojzBS8G9yXbhx42GHUOVLr4X2w==",
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-7.2.3.tgz",
+      "integrity": "sha512-i6j7sqcLEqTYqUcMV327waI745VASvYuSuQMCjbAwlpAeuCgKZ3LtrjDxAbu+GjNQR0FEDpywtwGCIh8GicNyg==",
       "dev": true,
       "requires": {
-        "@sinonjs/formatio": "^2.0.0",
-        "diff": "^3.1.0",
-        "lodash.get": "^4.4.2",
-        "lolex": "^2.2.0",
-        "nise": "^1.2.0",
-        "supports-color": "^5.1.0",
-        "type-detect": "^4.0.5"
+        "@sinonjs/commons": "^1.3.0",
+        "@sinonjs/formatio": "^3.1.0",
+        "@sinonjs/samsam": "^3.0.2",
+        "diff": "^3.5.0",
+        "lolex": "^3.0.0",
+        "nise": "^1.4.8",
+        "supports-color": "^5.5.0"
       },
       "dependencies": {
         "has-flag": {

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "rimraf": "^2.6.2",
     "selenium-webdriver": "^4.0.0-alpha.1",
     "shelljs": "^0.8.1",
-    "sinon": "^4.1.2",
+    "sinon": "^7.2.3",
     "style-loader": "^0.21.0",
     "ts-node": "^6.0.1",
     "tslint": "^5.8.0",

--- a/test/app/background/api/browserActionAPITest.ts
+++ b/test/app/background/api/browserActionAPITest.ts
@@ -42,9 +42,9 @@ describe('BrowserAction API', () => {
       this.enableSpy.restore()
     })
     afterEach(function () {
-      this.setIconSpy.reset()
-      this.disableSpy.reset()
-      this.enableSpy.reset()
+      this.setIconSpy.resetHistory()
+      this.disableSpy.resetHistory()
+      this.enableSpy.resetHistory()
     })
     it('sets enabled when protocol is http', function () {
       this.url = 'http://not-very-awesome-http-page.com'

--- a/test/app/background/api/cosmeticFilterAPITest.ts
+++ b/test/app/background/api/cosmeticFilterAPITest.ts
@@ -19,8 +19,8 @@ describe('cosmeticFilterTestSuite', () => {
       this.setStorageStub.restore()
     })
     beforeEach(function () {
-      this.getStorageStub.reset()
-      this.setStorageStub.reset()
+      this.getStorageStub.resetHistory()
+      this.setStorageStub.resetHistory()
     })
 
     it('passes only 1 arg to chrome.storage.local.set', function () {
@@ -77,8 +77,8 @@ describe('cosmeticFilterTestSuite', () => {
       this.setStorageStub.restore()
     })
     beforeEach(function () {
-      this.getStorageStub.reset()
-      this.setStorageStub.reset()
+      this.getStorageStub.resetHistory()
+      this.setStorageStub.resetHistory()
     })
     it('passes only 1 arg to chrome.storage.local.set', function () {
       this.getStorageStub.yields({
@@ -141,8 +141,8 @@ describe('cosmeticFilterTestSuite', () => {
       this.setStorageStub.restore()
     })
     beforeEach(function () {
-      this.getStorageStub.reset()
-      this.setStorageStub.reset()
+      this.getStorageStub.resetHistory()
+      this.setStorageStub.resetHistory()
     })
 
     it('sets empty list object', function () {
@@ -172,9 +172,9 @@ describe('cosmeticFilterTestSuite', () => {
       this.insertCSSStub.restore()
     })
     beforeEach(function () {
-      this.getStorageStub.reset()
-      this.setStorageStub.reset()
-      this.insertCSSStub.reset()
+      this.getStorageStub.resetHistory()
+      this.setStorageStub.resetHistory()
+      this.insertCSSStub.resetHistory()
     })
     it('applies the correct filter', function () {
       this.getStorageStub.yields({

--- a/test/app/background/api/tabsAPITest.ts
+++ b/test/app/background/api/tabsAPITest.ts
@@ -34,7 +34,7 @@ describe('tabs API', () => {
       this.spy.restore()
     })
     afterEach(function () {
-      this.spy.reset()
+      this.spy.resetHistory()
     })
     it('calls chrome.tabs.reload without bypassing the cache', function (cb) {
       const tabId = 42

--- a/test/app/background/reducers/cosmeticFilterReducerTest.ts
+++ b/test/app/background/reducers/cosmeticFilterReducerTest.ts
@@ -41,8 +41,8 @@ describe('cosmeticFilterReducer', () => {
       this.resetBlockingResourcesSpy.restore()
     })
     afterEach(function () {
-      this.spy.reset()
-      this.resetNoScriptInfoSpy.reset()
+      this.spy.resetHistory()
+      this.resetNoScriptInfoSpy.resetHistory()
     })
     it('calls resetBlockingStats when isMainFrame is true', function () {
       shieldsPanelReducer(initialState.shieldsPanel, {
@@ -163,7 +163,7 @@ describe('cosmeticFilterReducer', () => {
       this.updateActiveTabSpy.restore()
     })
     afterEach(function () {
-      this.updateActiveTabSpy.reset()
+      this.updateActiveTabSpy.resetHistory()
     })
     it('calls shieldsPanelState.updateActiveTab when the tab is active', function () {
       shieldsPanelReducer(this.state, {
@@ -221,7 +221,7 @@ describe('cosmeticFilterReducer', () => {
       this.updateActiveTabSpy.restore()
     })
     afterEach(function () {
-      this.updateActiveTabSpy.reset()
+      this.updateActiveTabSpy.resetHistory()
     })
     it('calls shieldsPanelState.updateActiveTab when the tab is active', function () {
       shieldsPanelReducer(this.state, {

--- a/test/app/background/reducers/shieldsPanelReducerTest.ts
+++ b/test/app/background/reducers/shieldsPanelReducerTest.ts
@@ -41,8 +41,8 @@ describe('braveShieldsPanelReducer', () => {
       this.resetBlockingResourcesSpy.restore()
     })
     afterEach(function () {
-      this.spy.reset()
-      this.resetNoScriptInfoSpy.reset()
+      this.spy.resetHistory()
+      this.resetNoScriptInfoSpy.resetHistory()
     })
     it('calls resetBlockingStats when isMainFrame is true', function () {
       shieldsPanelReducer(initialState.shieldsPanel, {
@@ -166,7 +166,7 @@ describe('braveShieldsPanelReducer', () => {
       this.updateActiveTabSpy.restore()
     })
     afterEach(function () {
-      this.updateActiveTabSpy.reset()
+      this.updateActiveTabSpy.resetHistory()
     })
     it('calls shieldsPanelState.updateActiveTab when the tab is active', function () {
       shieldsPanelReducer(this.state, {
@@ -225,7 +225,7 @@ describe('braveShieldsPanelReducer', () => {
       this.updateActiveTabSpy.restore()
     })
     afterEach(function () {
-      this.updateActiveTabSpy.reset()
+      this.updateActiveTabSpy.resetHistory()
     })
     it('calls shieldsPanelState.updateActiveTab when the tab is active', function () {
       shieldsPanelReducer(this.state, {


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/3262

Right now brave-core includes brave-extension at the following commit refs:

master - d1a956accdbb38a51bede5d463edb299012d0fe8
0.61.x - 70550a1619139459119f472c18a03dc12c3ed5f2 (diff https://github.com/brave/brave-extension/compare/master..70550a1)
0.60.x - 70550a1619139459119f472c18a03dc12c3ed5f2
0.59.x - 038a43af5294150d48ce94a326290f70aa001cd0 (diff https://github.com/brave/brave-extension/compare/master..038a43a)

So we may need to cherry-pick this fix in to branches from those shas if we don't want to bring in any other brave-extension changes to those brave-core branches.

This is a low-risk change since it only affects unit tests (which all pass)