### PR TITLE
Wait until "Block by CSS selector" context menu is clicked to find unique css selector

### DIFF
--- a/app/background/events/cosmeticFilterEvents.ts
+++ b/app/background/events/cosmeticFilterEvents.ts
@@ -36,11 +36,9 @@ chrome.contextMenus.onClicked.addListener(function (info, tab) {
   switch (info.menuItemId) {
     case 'addBlockElement':
       {
-        rule.selector = window.prompt('CSS selector to block: ', `${rule.selector}`) || ''
-        chrome.tabs.insertCSS({
-          code: `${rule.selector} {display: none;}`
+        chrome.runtime.sendMessage({
+          type: 'addBlockElement'
         })
-        cosmeticFilterActions.siteCosmeticFilterAdded(rule.host, rule.selector)
         break
       }
     case 'resetSiteFilterSettings':
@@ -63,5 +61,10 @@ chrome.contextMenus.onClicked.addListener(function (info, tab) {
 chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
   rule.host = msg.baseURI
   rule.selector = msg.selector
+  rule.selector = window.prompt('CSS selector to block: ', `${rule.selector}`) || ''
+  chrome.tabs.insertCSS({
+    code: `${rule.selector} {display: none;}`
+  })
+  cosmeticFilterActions.siteCosmeticFilterAdded(rule.host, rule.selector)
   sendResponse(rule)
 })

--- a/app/content.ts
+++ b/app/content.ts
@@ -1,15 +1,19 @@
 const unique = require('unique-selector').default
-
-function getCurrentURL () {
-  return window.location.hostname
-}
+let target: EventTarget | null
 
 document.addEventListener('contextmenu', (event) => {
-  let selector = unique(event.target) // this has to be done here, events can't be passed through the messaging API
-  let baseURI = getCurrentURL()
-
-  chrome.runtime.sendMessage({
-    selector: selector,
-    baseURI: baseURI
-  })
+  target = event.target
 }, true)
+
+chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+  const action = typeof msg === 'string' ? msg : msg.type
+  switch (action) {
+    case 'addBlockElement': {
+      sendResponse({
+        selector: unique(target),
+        baseURI: window.location.hostname
+      })
+      break
+    }
+  }
+})


### PR DESCRIPTION
There's a performance issue when right-clicking on a Twitter timeline, this is due to the way Twitter builds it's elements (with dozens of css class names) which impacts the way the library `unique-selector` finds elements. This causes a few seconds delay every time anything on a Twitter timeline is clicked.

You can see a bit more details here: https://community.brave.com/t/right-click-hangs-on-mobile-twitter/43332/4

This PR rewrites `app/content.ts` and `app/background/events/cosmeticFilterEvents.ts` so that the actual `unique` call only happens after the Context sub menu item is clicked.

FYI, I wasn't able to get this changes running locally, so I've wrote this PR blindly – I not 100% sure it's going to work.